### PR TITLE
feat(docs): add instructions for creating new devcontainer features

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,16 @@
+## Commit Messages.
+
+We follow conventional commit specification for commit messages. This means that each commit message should start with a type, followed by an optional scope, and then a description. The types we use are:
+
+- **feat**: A new feature
+- **fix**: A bug fix
+- **docs**: Documentation only changes
+- **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
+- **refactor**: A code change that neither fixes a bug nor adds a feature
+- **perf**: A code change that improves performance
+- **test**: Adding missing or correcting existing tests
+- **build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
+- **ci**: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
+- **chore**: Other changes that don't modify src or test files
+
+More details in here https://www.conventionalcommits.org/en/v1.0.0/

--- a/.github/prompts/new-feature.prompt.md
+++ b/.github/prompts/new-feature.prompt.md
@@ -1,0 +1,14 @@
+You are a useful agent that helps users creating devcontainer features. The repository hosts different features and when a user requests for a new feature you help them creating the feature.
+
+You follow these steps:
+- create a new branch from latest main. branch name should be feat/<feature_name>
+- create a folder under src for the feature
+- create a devcontainer-feature.json file in the folder. Use the example in ../../src/gic/devcontainer-feature.json as a template
+- create a install.sh file in the folder. Use the example in ../../src/gic/install.sh as a template. If the user gives you a github repository, check its releases to work out the flow to install the binary. Usually, identify the version, if no version is given, use the latest version. If the user gives you a version, use that version, remember to check the version exists. Then validate the binary type, we need to have an executable binary installed in the running os.
+- give execution permission to the install.sh file and run it as sudo user (sudo su)
+- create a folder under test for the feature
+- create a test.sh file in the folder. Use the example in ../../test/gic/test.sh as a template.
+- update ../../test/_global/all-tools.sh to validate the new feature is installed.
+- if a specific version can be installed, create a feature_name-specific-version.sh under test/_global. Use the example in ../../test/_global/gic-specific-version.sh as a template. Update the ../../test/_global/scenarios.json
+- update the ../workflows/test.yaml to include the new feature
+- finally, update the README.md file to include the new feature. Update the table and the usage section.


### PR DESCRIPTION
This pull request introduces updates to the documentation and developer prompts to standardize processes and improve clarity. The key changes include adding guidelines for commit messages and providing detailed instructions for creating new devcontainer features.

### Documentation Updates:
* [`.github/copilot-instructions.md`](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R1-R16): Added a new section outlining the use of the Conventional Commit specification for commit messages, including a list of supported types (e.g., `feat`, `fix`, `docs`) and a link for further details.

### Developer Workflow Enhancements:
* [`.github/prompts/new-feature.prompt.md`](diffhunk://#diff-0b9bbbc86b7c5a9d05464d9d8848c8cff0b97eb55bfc66c2d5c36d42d8df5942R1-R14): Added a detailed prompt describing the steps to create a new devcontainer feature, including branch naming conventions, file creation, permission settings, test updates, and documentation updates.