### PR TITLE
fix(yazi): use musl builds to avoid GLIBC_2.39 requirement

### DIFF
--- a/src/yazi/devcontainer-feature.json
+++ b/src/yazi/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "Yazi",
     "id": "yazi",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Blazing fast terminal file manager written in Rust, based on async I/O.",
     "options": {
         "version": {

--- a/src/yazi/install.sh
+++ b/src/yazi/install.sh
@@ -47,15 +47,21 @@ fi
 # Determine the OS and architecture
 ARCH=$(uname -m)
 
+# Prefer musl builds (statically linked) so the binary doesn't depend on
+# the host's GLIBC version. Recent yazi releases require GLIBC >= 2.39 for
+# the -gnu builds, which is newer than Debian/Ubuntu stable provide.
 case "$ARCH" in
     x86_64)
         ARCH="x86_64"
+        LIBC="musl"
         ;;
     aarch64)
         ARCH="aarch64"
+        LIBC="musl"
         ;;
     i686)
         ARCH="i686"
+        LIBC="gnu"
         ;;
     *)
         echo "Unsupported architecture: $ARCH"
@@ -64,8 +70,8 @@ case "$ARCH" in
 esac
 
 # Construct the download URL
-# Asset pattern: yazi-{ARCH}-unknown-linux-gnu.zip
-ASSET_NAME="${BINARY_NAME}-${ARCH}-unknown-linux-gnu"
+# Asset pattern: yazi-{ARCH}-unknown-linux-{LIBC}.zip
+ASSET_NAME="${BINARY_NAME}-${ARCH}-unknown-linux-${LIBC}"
 DOWNLOAD_URL="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/${YAZI_VERSION}/${ASSET_NAME}.zip"
 
 # Create a temporary directory for the download


### PR DESCRIPTION
## Problem

Installing the `yazi` feature fails on Debian/Ubuntu base images:

```
Verifying installation...
GLIBC_2.39
ERROR: Feature "Yazi" (ghcr.io/jsburckhardt/devcontainer-features/yazi) failed to install!
```

Recent yazi releases link the `-unknown-linux-gnu` builds against GLIBC 2.39, which is newer than what current Debian/Ubuntu stable images ship.

## Fix

Switch x86_64 and aarch64 installs to the statically-linked `-unknown-linux-musl` variant published on the same release. i686 keeps `-gnu` since no musl asset is published for it.

Bumped feature version `1.0.0` → `1.0.1`.

## Verification

```
devcontainer features test -f yazi -i ubuntu:latest .
```

Result: ✅ Passed (Yazi 26.1.22)