### PR TITLE
feat(zoxide): add zoxide devcontainer feature

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,6 +32,7 @@ jobs:
           - opencode
           - ccc
           - tmux
+          - zoxide
         baseImage:
           - debian:latest
           - ubuntu:latest

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This repository contains a _collection_ of Features.
 | ccc | https://github.com/jsburckhardt/co-config | A TUI tool to interactively configure and view GitHub Copilot CLI settings. |
 | Yazi | https://github.com/sxyazi/yazi | Blazing fast terminal file manager written in Rust, based on async I/O. |
 | tmux | https://github.com/tmux/tmux | tmux is a terminal multiplexer. It lets you switch easily between several programs in one terminal. |
+| zoxide | https://github.com/ajeetdsouza/zoxide | A smarter cd command. Supports all major shells. |
 
 
 
@@ -390,4 +391,21 @@ Running `tmux -V` inside the built container will print the version of tmux.
 
 ```bash
 tmux -V
+```
+
+### `zoxide`
+
+Running `zoxide --version` inside the built container will print the version of zoxide.
+
+```jsonc
+{
+    "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+    "features": {
+        "ghcr.io/jsburckhardt/devcontainer-features/zoxide:1": {}
+    }
+}
+```
+
+```bash
+zoxide --version
 ```

--- a/src/zoxide/devcontainer-feature.json
+++ b/src/zoxide/devcontainer-feature.json
@@ -1,0 +1,13 @@
+{
+    "name": "zoxide",
+    "id": "zoxide",
+    "version": "1.0.0",
+    "description": "A smarter cd command. Supports all major shells.",
+    "options": {
+        "version": {
+            "type": "string",
+            "default": "latest",
+            "description": "Version of zoxide to install from GitHub releases e.g. v0.9.9"
+        }
+    }
+}

--- a/src/zoxide/install.sh
+++ b/src/zoxide/install.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+
+# Variables
+REPO_OWNER="ajeetdsouza"
+REPO_NAME="zoxide"
+BINARY_NAME="zoxide"
+ZOXIDE_VERSION="${VERSION:-"latest"}"
+GITHUB_API_REPO_URL="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases"
+
+set -e
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+# Checks if packages are installed and installs them if not
+check_packages() {
+    if ! dpkg -s "$@" >/dev/null 2>&1; then
+        if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+            echo "Running apt-get update..."
+            apt-get update -y
+        fi
+        apt-get -y install --no-install-recommends "$@"
+    fi
+}
+
+# Make sure we have curl and jq
+check_packages curl jq ca-certificates
+
+# Function to get the latest version from GitHub API
+get_latest_version() {
+    curl -s "${GITHUB_API_REPO_URL}/latest" | jq -r ".tag_name"
+}
+
+# Check if a version is passed as an argument
+if [ -z "$ZOXIDE_VERSION" ] || [ "$ZOXIDE_VERSION" == "latest" ]; then
+    # No version provided, get the latest version
+    ZOXIDE_VERSION=$(get_latest_version)
+    echo "No version provided or 'latest' specified, installing the latest version: $ZOXIDE_VERSION"
+else
+    echo "Installing version from environment variable: $ZOXIDE_VERSION"
+fi
+
+# Strip the leading 'v' for the download URL filename
+VERSION_NO_V="${ZOXIDE_VERSION#v}"
+
+# Determine the OS and architecture
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+
+case "$ARCH" in
+    x86_64)
+        ARCH="x86_64"
+        ;;
+    i686)
+        ARCH="i686"
+        ;;
+    aarch64)
+        ARCH="aarch64"
+        ;;
+    armv7l)
+        ARCH="armv7"
+        ;;
+    *)
+        echo "Unsupported architecture: $ARCH"
+        exit 1
+        ;;
+esac
+
+case "$OS" in
+    linux)
+        OS="unknown-linux-musl"
+        ;;
+    darwin)
+        OS="apple-darwin"
+        ;;
+    *)
+        echo "Unsupported OS: $OS"
+        exit 1
+        ;;
+esac
+
+# Construct the download URL
+DOWNLOAD_URL="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/${ZOXIDE_VERSION}/zoxide-${VERSION_NO_V}-${ARCH}-${OS}.tar.gz"
+
+# Create a temporary directory for the download
+TMP_DIR=$(mktemp -d)
+cd "$TMP_DIR" || exit
+
+echo "Downloading zoxide from $DOWNLOAD_URL"
+curl -sSL "$DOWNLOAD_URL" -o "zoxide.tar.gz"
+
+# Extract the tarball
+echo "Extracting zoxide..."
+tar -xzf "zoxide.tar.gz"
+
+# Move the binary to /usr/local/bin
+echo "Installing zoxide..."
+mv zoxide /usr/local/bin/
+chmod +x /usr/local/bin/zoxide
+
+# Cleanup
+cd - || exit
+rm -rf "$TMP_DIR"
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+# Verify installation
+echo "Verifying installation..."
+zoxide --version
+
+echo "Done!"

--- a/test/_global/all-tools.sh
+++ b/test/_global/all-tools.sh
@@ -21,5 +21,6 @@ check "opencode" opencode --version
 check "ccc" ccc --version
 check "yazi" yazi --version
 check "tmux" tmux -V
+check "zoxide" zoxide --version
 
 reportResults

--- a/test/_global/scenarios.json
+++ b/test/_global/scenarios.json
@@ -22,7 +22,8 @@
             "opencode": {},
             "ccc": {},
             "yazi": {},
-            "tmux": {}
+            "tmux": {},
+            "zoxide": {}
         }
     },
     "flux-specific-version": {
@@ -171,6 +172,14 @@
         "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
         "features": {
             "tmux": {}
+        }
+    },
+    "zoxide-specific-version": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "zoxide": {
+                "version": "v0.9.6"
+            }
         }
     }
 }

--- a/test/_global/zoxide-specific-version.sh
+++ b/test/_global/zoxide-specific-version.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+source dev-container-features-test-lib
+check "zoxide with specific version" /bin/bash -c "zoxide --version | grep '0.9.6'"
+
+reportResults

--- a/test/zoxide/test.sh
+++ b/test/zoxide/test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+source dev-container-features-test-lib
+check "zoxide" zoxide --version
+reportResults


### PR DESCRIPTION
## Summary

Add zoxide as a new devcontainer feature. Zoxide is a smarter cd command that supports all major shells (36k+ stars on GitHub).

## Changes

### New files
- `src/zoxide/devcontainer-feature.json` — Feature metadata with version option
- `src/zoxide/install.sh` — Installer downloading from GitHub releases (musl builds)
- `test/zoxide/test.sh` — Basic smoke test
- `test/_global/zoxide-specific-version.sh` — Version-pinned test (v0.9.6)

### Updated files
- `test/_global/all-tools.sh` — Added zoxide check
- `test/_global/scenarios.json` — Added zoxide to all-tools and version-pinned scenario
- `.github/workflows/test.yaml` — Added zoxide to test matrix
- `README.md` — Added table row and usage section

Closes #98