### PR TITLE
feat(glow): add glow devcontainer feature

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,6 +32,7 @@ jobs:
           - opencode
           - ccc
           - tmux
+          - glow
         baseImage:
           - debian:latest
           - ubuntu:latest

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This repository contains a _collection_ of Features.
 | ccc | https://github.com/jsburckhardt/co-config | A TUI tool to interactively configure and view GitHub Copilot CLI settings. |
 | Yazi | https://github.com/sxyazi/yazi | Blazing fast terminal file manager written in Rust, based on async I/O. |
 | tmux | https://github.com/tmux/tmux | tmux is a terminal multiplexer. It lets you switch easily between several programs in one terminal. |
+| Glow | https://github.com/charmbracelet/glow | Render markdown on the CLI, with pizzazz! 💅🏻 |
 
 
 
@@ -390,4 +391,21 @@ Running `tmux -V` inside the built container will print the version of tmux.
 
 ```bash
 tmux -V
+```
+
+### `glow`
+
+Running `glow --version` inside the built container will print the version of glow.
+
+```jsonc
+{
+    "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+    "features": {
+        "ghcr.io/jsburckhardt/devcontainer-features/glow:1": {}
+    }
+}
+```
+
+```bash
+glow --version
 ```

--- a/src/glow/devcontainer-feature.json
+++ b/src/glow/devcontainer-feature.json
@@ -1,0 +1,13 @@
+{
+    "name": "Glow",
+    "id": "glow",
+    "version": "1.0.0",
+    "description": "Render markdown on the CLI, with pizzazz! 💅🏻",
+    "options": {
+        "version": {
+            "type": "string",
+            "default": "latest",
+            "description": "Version of glow to install from GitHub releases e.g. v2.1.2"
+        }
+    }
+}

--- a/src/glow/install.sh
+++ b/src/glow/install.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+
+# Variables
+REPO_OWNER="charmbracelet"
+REPO_NAME="glow"
+BINARY_NAME="glow"
+GLOW_VERSION="${VERSION:-"latest"}"
+GITHUB_API_REPO_URL="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases"
+
+set -e
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+# Checks if packages are installed and installs them if not
+check_packages() {
+    if ! dpkg -s "$@" >/dev/null 2>&1; then
+        if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+            echo "Running apt-get update..."
+            apt-get update -y
+        fi
+        apt-get -y install --no-install-recommends "$@"
+    fi
+}
+
+# Make sure we have curl and jq
+check_packages curl jq ca-certificates
+
+# Function to get the latest version from GitHub API
+get_latest_version() {
+    curl -s "${GITHUB_API_REPO_URL}/latest" | jq -r ".tag_name"
+}
+
+# Check if a version is passed as an argument
+if [ -z "$GLOW_VERSION" ] || [ "$GLOW_VERSION" == "latest" ]; then
+    # No version provided, get the latest version
+    GLOW_VERSION=$(get_latest_version)
+    echo "No version provided or 'latest' specified, installing the latest version: $GLOW_VERSION"
+else
+    echo "Installing version from environment variable: $GLOW_VERSION"
+fi
+
+# Strip the leading 'v' for the download URL filename
+VERSION_NO_V="${GLOW_VERSION#v}"
+
+# Determine the OS and architecture
+OS=$(uname -s)
+ARCH=$(uname -m)
+
+case "$ARCH" in
+    x86_64)
+        ARCH="x86_64"
+        ;;
+    i686 | i386)
+        ARCH="i386"
+        ;;
+    aarch64 | arm64)
+        ARCH="arm64"
+        ;;
+    armv7l)
+        ARCH="arm"
+        ;;
+    *)
+        echo "Unsupported architecture: $ARCH"
+        exit 1
+        ;;
+esac
+
+case "$OS" in
+    Linux)
+        OS="Linux"
+        ;;
+    Darwin)
+        OS="Darwin"
+        ;;
+    *)
+        echo "Unsupported OS: $OS"
+        exit 1
+        ;;
+esac
+
+# Construct the download URL
+DOWNLOAD_URL="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/${GLOW_VERSION}/glow_${VERSION_NO_V}_${OS}_${ARCH}.tar.gz"
+
+# Create a temporary directory for the download
+TMP_DIR=$(mktemp -d)
+cd "$TMP_DIR" || exit
+
+echo "Downloading glow from $DOWNLOAD_URL"
+curl -sSL "$DOWNLOAD_URL" -o "glow.tar.gz"
+
+# Extract the tarball
+echo "Extracting glow..."
+tar -xzf "glow.tar.gz"
+
+# Move the binary to /usr/local/bin
+echo "Installing glow..."
+mv glow /usr/local/bin/
+chmod +x /usr/local/bin/glow
+
+# Cleanup
+cd - || exit
+rm -rf "$TMP_DIR"
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+# Verify installation
+echo "Verifying installation..."
+glow --version
+
+echo "Done!"

--- a/test/_global/all-tools.sh
+++ b/test/_global/all-tools.sh
@@ -21,5 +21,6 @@ check "opencode" opencode --version
 check "ccc" ccc --version
 check "yazi" yazi --version
 check "tmux" tmux -V
+check "glow" glow --version
 
 reportResults

--- a/test/_global/glow-specific-version.sh
+++ b/test/_global/glow-specific-version.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+source dev-container-features-test-lib
+check "glow with specific version" /bin/bash -c "glow --version | grep '2.1.2'"
+
+reportResults

--- a/test/_global/scenarios.json
+++ b/test/_global/scenarios.json
@@ -22,7 +22,8 @@
             "opencode": {},
             "ccc": {},
             "yazi": {},
-            "tmux": {}
+            "tmux": {},
+            "glow": {}
         }
     },
     "flux-specific-version": {
@@ -171,6 +172,14 @@
         "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
         "features": {
             "tmux": {}
+        }
+    },
+    "glow-specific-version": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "glow": {
+                "version": "v2.1.2"
+            }
         }
     }
 }

--- a/test/glow/test.sh
+++ b/test/glow/test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+source dev-container-features-test-lib
+check "glow" glow --version
+reportResults


### PR DESCRIPTION
## Summary

Add [glow](https://github.com/charmbracelet/glow) as a new devcontainer feature. Glow renders markdown on the CLI, with pizzazz! 💅🏻

## Changes

### New files
- `src/glow/devcontainer-feature.json` — Feature metadata
- `src/glow/install.sh` — Installer that downloads from GitHub releases
- `test/glow/test.sh` — Basic smoke test
- `test/_global/glow-specific-version.sh` — Version-pinned test (v2.1.2)

### Updated files
- `test/_global/all-tools.sh` — Added glow check
- `test/_global/scenarios.json` — Added glow to all-tools and version-pinned scenario
- `.github/workflows/test.yaml` — Added glow to test matrix
- `README.md` — Added glow to features table and usage section

Closes #100