### PR TITLE
feat(ripgrep): add ripgrep devcontainer feature

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,6 +32,7 @@ jobs:
           - opencode
           - ccc
           - tmux
+          - ripgrep
         baseImage:
           - debian:latest
           - ubuntu:latest

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This repository contains a _collection_ of Features.
 | ccc | https://github.com/jsburckhardt/co-config | A TUI tool to interactively configure and view GitHub Copilot CLI settings. |
 | Yazi | https://github.com/sxyazi/yazi | Blazing fast terminal file manager written in Rust, based on async I/O. |
 | tmux | https://github.com/tmux/tmux | tmux is a terminal multiplexer. It lets you switch easily between several programs in one terminal. |
+| ripgrep | https://github.com/BurntSushi/ripgrep | Recursively searches directories for a regex pattern while respecting your gitignore. |
 
 
 
@@ -390,4 +391,21 @@ Running `tmux -V` inside the built container will print the version of tmux.
 
 ```bash
 tmux -V
+```
+
+### `ripgrep`
+
+Running `rg --version` inside the built container will print the version of ripgrep.
+
+```jsonc
+{
+    "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+    "features": {
+        "ghcr.io/jsburckhardt/devcontainer-features/ripgrep:1": {}
+    }
+}
+```
+
+```bash
+rg --version
 ```

--- a/src/ripgrep/devcontainer-feature.json
+++ b/src/ripgrep/devcontainer-feature.json
@@ -1,0 +1,13 @@
+{
+    "name": "ripgrep",
+    "id": "ripgrep",
+    "version": "1.0.0",
+    "description": "Recursively searches directories for a regex pattern while respecting your gitignore.",
+    "options": {
+        "version": {
+            "type": "string",
+            "default": "latest",
+            "description": "Version of ripgrep to install from GitHub releases e.g. 14.1.1"
+        }
+    }
+}

--- a/src/ripgrep/install.sh
+++ b/src/ripgrep/install.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+
+# Variables
+REPO_OWNER="BurntSushi"
+REPO_NAME="ripgrep"
+BINARY_NAME="rg"
+RIPGREP_VERSION="${VERSION:-"latest"}"
+GITHUB_API_REPO_URL="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases"
+
+set -e
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+# Checks if packages are installed and installs them if not
+check_packages() {
+    if ! dpkg -s "$@" >/dev/null 2>&1; then
+        if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+            echo "Running apt-get update..."
+            apt-get update -y
+        fi
+        apt-get -y install --no-install-recommends "$@"
+    fi
+}
+
+# Make sure we have curl and jq
+check_packages curl jq ca-certificates
+
+# Function to get the latest version from GitHub API
+get_latest_version() {
+    curl -s "${GITHUB_API_REPO_URL}/latest" | jq -r ".tag_name"
+}
+
+# Check if a version is passed as an argument
+if [ -z "$RIPGREP_VERSION" ] || [ "$RIPGREP_VERSION" == "latest" ]; then
+    # No version provided, get the latest version
+    RIPGREP_VERSION=$(get_latest_version)
+    echo "No version provided or 'latest' specified, installing the latest version: $RIPGREP_VERSION"
+else
+    echo "Installing version from environment variable: $RIPGREP_VERSION"
+fi
+
+# Determine the OS and architecture
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+
+case "$ARCH" in
+    x86_64)
+        ARCH_TRIPLE="x86_64-unknown-linux-musl"
+        ;;
+    i686)
+        ARCH_TRIPLE="i686-unknown-linux-gnu"
+        ;;
+    aarch64)
+        ARCH_TRIPLE="aarch64-unknown-linux-gnu"
+        ;;
+    armv7l)
+        ARCH_TRIPLE="armv7-unknown-linux-gnueabihf"
+        ;;
+    *)
+        echo "Unsupported architecture: $ARCH"
+        exit 1
+        ;;
+esac
+
+case "$OS" in
+    linux)
+        # ARCH_TRIPLE already set above for linux
+        ;;
+    darwin)
+        case "$ARCH" in
+            x86_64)
+                ARCH_TRIPLE="x86_64-apple-darwin"
+                ;;
+            aarch64|arm64)
+                ARCH_TRIPLE="aarch64-apple-darwin"
+                ;;
+            *)
+                echo "Unsupported architecture on macOS: $ARCH"
+                exit 1
+                ;;
+        esac
+        ;;
+    *)
+        echo "Unsupported OS: $OS"
+        exit 1
+        ;;
+esac
+
+# Construct the download URL
+DOWNLOAD_URL="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/${RIPGREP_VERSION}/ripgrep-${RIPGREP_VERSION}-${ARCH_TRIPLE}.tar.gz"
+
+# Create a temporary directory for the download
+TMP_DIR=$(mktemp -d)
+cd "$TMP_DIR" || exit
+
+echo "Downloading ripgrep from $DOWNLOAD_URL"
+curl -sSL "$DOWNLOAD_URL" -o "ripgrep.tar.gz"
+
+# Extract the tarball
+echo "Extracting ripgrep..."
+tar -xzf "ripgrep.tar.gz"
+
+# Find the extracted directory
+EXTRACTED_DIR=$(find . -name "ripgrep-${RIPGREP_VERSION}-*" -type d | head -1)
+if [ -z "$EXTRACTED_DIR" ]; then
+    echo "ERROR: Could not find extracted ripgrep directory"
+    exit 1
+fi
+
+# Move the binary to /usr/local/bin
+echo "Installing ripgrep..."
+mv "${EXTRACTED_DIR}/rg" /usr/local/bin/
+
+# Cleanup
+cd - || exit
+rm -rf "$TMP_DIR"
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+# Verify installation
+echo "Verifying installation..."
+rg --version
+
+echo "Done!"

--- a/test/_global/all-tools.sh
+++ b/test/_global/all-tools.sh
@@ -21,5 +21,6 @@ check "opencode" opencode --version
 check "ccc" ccc --version
 check "yazi" yazi --version
 check "tmux" tmux -V
+check "ripgrep" rg --version
 
 reportResults

--- a/test/_global/ripgrep-specific-version.sh
+++ b/test/_global/ripgrep-specific-version.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+source dev-container-features-test-lib
+check "ripgrep with specific version" /bin/bash -c "rg --version | grep '14.1.1'"
+
+reportResults

--- a/test/_global/scenarios.json
+++ b/test/_global/scenarios.json
@@ -22,7 +22,8 @@
             "opencode": {},
             "ccc": {},
             "yazi": {},
-            "tmux": {}
+            "tmux": {},
+            "ripgrep": {}
         }
     },
     "flux-specific-version": {
@@ -171,6 +172,14 @@
         "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
         "features": {
             "tmux": {}
+        }
+    },
+    "ripgrep-specific-version": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "ripgrep": {
+                "version": "14.1.1"
+            }
         }
     }
 }

--- a/test/ripgrep/test.sh
+++ b/test/ripgrep/test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+source dev-container-features-test-lib
+check "ripgrep" rg --version
+reportResults


### PR DESCRIPTION
## Summary

Add ripgrep as a new devcontainer feature.

**ripgrep** (rg) is a line-oriented search tool that recursively searches the current directory for a regex pattern while respecting .gitignore rules. It is similar to other search tools like grep, ag, and ack but is significantly faster.

- **Source:** https://github.com/BurntSushi/ripgrep
- **Binary:** `rg`
- **Default version:** latest (from GitHub releases)

## Changes

### New files
- `src/ripgrep/devcontainer-feature.json` — Feature metadata
- `src/ripgrep/install.sh` — Installer (downloads from GitHub releases, supports x86_64/aarch64/i686/armv7l)
- `test/ripgrep/test.sh` — Basic smoke test
- `test/_global/ripgrep-specific-version.sh` — Version-pinned test (14.1.1)

### Updated files
- `test/_global/scenarios.json` — Added ripgrep to all-tools and version-pinned scenario
- `test/_global/all-tools.sh` — Added ripgrep check
- `.github/workflows/test.yaml` — Added ripgrep to CI matrix
- `README.md` — Added table row and usage section

Closes #95