### PR TITLE
feat(lazygit): add lazygit devcontainer feature

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,6 +32,7 @@ jobs:
           - opencode
           - ccc
           - tmux
+          - lazygit
         baseImage:
           - debian:latest
           - ubuntu:latest

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This repository contains a _collection_ of Features.
 | ccc | https://github.com/jsburckhardt/co-config | A TUI tool to interactively configure and view GitHub Copilot CLI settings. |
 | Yazi | https://github.com/sxyazi/yazi | Blazing fast terminal file manager written in Rust, based on async I/O. |
 | tmux | https://github.com/tmux/tmux | tmux is a terminal multiplexer. It lets you switch easily between several programs in one terminal. |
+| lazygit | https://github.com/jesseduffield/lazygit | Simple terminal UI for git commands. |
 
 
 
@@ -390,4 +391,21 @@ Running `tmux -V` inside the built container will print the version of tmux.
 
 ```bash
 tmux -V
+```
+
+### `lazygit`
+
+Running `lazygit --version` inside the built container will print the version of lazygit.
+
+```jsonc
+{
+    "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+    "features": {
+        "ghcr.io/jsburckhardt/devcontainer-features/lazygit:1": {}
+    }
+}
+```
+
+```bash
+lazygit --version
 ```

--- a/src/lazygit/devcontainer-feature.json
+++ b/src/lazygit/devcontainer-feature.json
@@ -1,0 +1,13 @@
+{
+    "name": "lazygit",
+    "id": "lazygit",
+    "version": "1.0.0",
+    "description": "Simple terminal UI for git commands.",
+    "options": {
+        "version": {
+            "type": "string",
+            "default": "latest",
+            "description": "Version of lazygit to install from GitHub releases e.g. v0.61.1"
+        }
+    }
+}

--- a/src/lazygit/install.sh
+++ b/src/lazygit/install.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+
+# Variables
+REPO_OWNER="jesseduffield"
+REPO_NAME="lazygit"
+BINARY_NAME="lazygit"
+LAZYGIT_VERSION="${VERSION:-"latest"}"
+GITHUB_API_REPO_URL="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases"
+
+set -e
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+# Checks if packages are installed and installs them if not
+check_packages() {
+    if ! dpkg -s "$@" >/dev/null 2>&1; then
+        if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+            echo "Running apt-get update..."
+            apt-get update -y
+        fi
+        apt-get -y install --no-install-recommends "$@"
+    fi
+}
+
+# Make sure we have curl and jq
+check_packages curl jq ca-certificates
+
+# Function to get the latest version from GitHub API
+get_latest_version() {
+    curl -s "${GITHUB_API_REPO_URL}/latest" | jq -r ".tag_name"
+}
+
+# Check if a version is passed as an argument
+if [ -z "$LAZYGIT_VERSION" ] || [ "$LAZYGIT_VERSION" == "latest" ]; then
+    # No version provided, get the latest version
+    LAZYGIT_VERSION=$(get_latest_version)
+    echo "No version provided or 'latest' specified, installing the latest version: $LAZYGIT_VERSION"
+else
+    echo "Installing version from environment variable: $LAZYGIT_VERSION"
+fi
+
+# Strip the leading 'v' for the download URL (assets use version without 'v' prefix)
+VERSION_NO_V="${LAZYGIT_VERSION#v}"
+
+# Determine the OS and architecture
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+
+case "$ARCH" in
+    x86_64)
+        ARCH="x86_64"
+        ;;
+    aarch64)
+        ARCH="arm64"
+        ;;
+    armv7l)
+        ARCH="armv6"
+        ;;
+    i686)
+        ARCH="32-bit"
+        ;;
+    *)
+        echo "Unsupported architecture: $ARCH"
+        exit 1
+        ;;
+esac
+
+case "$OS" in
+    linux)
+        OS="Linux"
+        ;;
+    darwin)
+        OS="Darwin"
+        ;;
+    *)
+        echo "Unsupported OS: $OS"
+        exit 1
+        ;;
+esac
+
+# Construct the download URL
+# Pattern: lazygit_{VERSION_NO_V}_{OS}_{ARCH}.tar.gz
+DOWNLOAD_URL="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/${LAZYGIT_VERSION}/lazygit_${VERSION_NO_V}_${OS}_${ARCH}.tar.gz"
+
+# Create a temporary directory for the download
+TMP_DIR=$(mktemp -d)
+cd "$TMP_DIR" || exit
+
+echo "Downloading lazygit from $DOWNLOAD_URL"
+curl -sSL "$DOWNLOAD_URL" -o "lazygit.tar.gz"
+
+# Extract the tarball
+echo "Extracting lazygit..."
+tar -xzf "lazygit.tar.gz"
+
+# Move the binary to /usr/local/bin
+echo "Installing lazygit..."
+mv lazygit /usr/local/bin/
+chmod +x /usr/local/bin/lazygit
+
+# Cleanup
+cd - || exit
+rm -rf "$TMP_DIR"
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+# Verify installation
+echo "Verifying installation..."
+lazygit --version
+
+echo "Done!"

--- a/test/_global/all-tools.sh
+++ b/test/_global/all-tools.sh
@@ -21,5 +21,6 @@ check "opencode" opencode --version
 check "ccc" ccc --version
 check "yazi" yazi --version
 check "tmux" tmux -V
+check "lazygit" lazygit --version
 
 reportResults

--- a/test/_global/lazygit-specific-version.sh
+++ b/test/_global/lazygit-specific-version.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+source dev-container-features-test-lib
+check "lazygit with specific version" /bin/bash -c "lazygit --version | grep '0.44.0'"
+
+reportResults

--- a/test/_global/scenarios.json
+++ b/test/_global/scenarios.json
@@ -22,7 +22,8 @@
             "opencode": {},
             "ccc": {},
             "yazi": {},
-            "tmux": {}
+            "tmux": {},
+            "lazygit": {}
         }
     },
     "flux-specific-version": {
@@ -164,6 +165,14 @@
         "features": {
             "yazi": {
                 "version": "v26.1.22"
+            }
+        }
+    },
+    "lazygit-specific-version": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "lazygit": {
+                "version": "v0.44.0"
             }
         }
     },

--- a/test/lazygit/test.sh
+++ b/test/lazygit/test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+source dev-container-features-test-lib
+check "lazygit" lazygit --version
+reportResults


### PR DESCRIPTION
Add lazygit as a new devcontainer feature.

## What
- **lazygit**: Simple terminal UI for git commands (https://github.com/jesseduffield/lazygit)

## Changes
- `src/lazygit/devcontainer-feature.json` — feature metadata
- `src/lazygit/install.sh` — installer downloading from GitHub releases
- `test/lazygit/test.sh` — basic smoke test
- `test/_global/lazygit-specific-version.sh` — version-pinned test (v0.44.0)
- Updated `test/_global/scenarios.json`, `test/_global/all-tools.sh`, `.github/workflows/test.yaml`, `README.md`

Closes #94

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>