### PR TITLE
feat: add 10 new devcontainer features (fzf, lazygit, ripgrep, fd, rtk, zoxide, hyperfine, glow, fx, hurl)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,6 +32,16 @@ jobs:
           - opencode
           - ccc
           - tmux
+          - fzf
+          - lazygit
+          - ripgrep
+          - fd
+          - rtk
+          - zoxide
+          - hyperfine
+          - glow
+          - fx
+          - hurl
         baseImage:
           - debian:latest
           - ubuntu:latest

--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ This repository contains a _collection_ of Features.
 | ccc | https://github.com/jsburckhardt/co-config | A TUI tool to interactively configure and view GitHub Copilot CLI settings. |
 | Yazi | https://github.com/sxyazi/yazi | Blazing fast terminal file manager written in Rust, based on async I/O. |
 | tmux | https://github.com/tmux/tmux | tmux is a terminal multiplexer. It lets you switch easily between several programs in one terminal. |
+| fzf | https://github.com/junegunn/fzf | A command-line fuzzy finder. |
+| lazygit | https://github.com/jesseduffield/lazygit | Simple terminal UI for git commands. |
+| ripgrep | https://github.com/BurntSushi/ripgrep | Recursively searches directories for a regex pattern while respecting your gitignore. |
+| fd | https://github.com/sharkdp/fd | A simple, fast and user-friendly alternative to 'find'. |
+| rtk | https://github.com/rtk-ai/rtk | CLI proxy that reduces LLM token consumption by 60-90% on common dev commands. Single Rust binary, zero dependencies. |
+| zoxide | https://github.com/ajeetdsouza/zoxide | A smarter cd command. Supports all major shells. |
+| hyperfine | https://github.com/sharkdp/hyperfine | A command-line benchmarking tool. |
+| Glow | https://github.com/charmbracelet/glow | Render markdown on the CLI, with pizzazz! 💅🏻 |
+| fx | https://github.com/antonmedv/fx | Terminal JSON viewer & processor. |
+| hurl | https://github.com/Orange-OpenSource/hurl | Run and test HTTP requests with plain text. |
 
 
 
@@ -390,4 +400,66 @@ Running `tmux -V` inside the built container will print the version of tmux.
 
 ```bash
 tmux -V
+```
+
+### `fzf`
+
+Running `fzf --version` inside the built container will print the version of fzf.
+### `lazygit`
+
+Running `lazygit --version` inside the built container will print the version of lazygit.
+### `ripgrep`
+
+Running `rg --version` inside the built container will print the version of ripgrep.
+### `fd`
+
+Running `fd --version` inside the built container will print the version of fd.
+### `rtk`
+
+Running `rtk --version` inside the built container will print the version of rtk.
+### `zoxide`
+
+Running `zoxide --version` inside the built container will print the version of zoxide.
+### `hyperfine`
+
+Running `hyperfine --version` inside the built container will print the version of hyperfine.
+### `glow`
+
+Running `glow --version` inside the built container will print the version of glow.
+### `fx`
+
+Running `fx --version` inside the built container will print the version of fx.
+### `hurl`
+
+Running `hurl --version` inside the built container will print the version of hurl.
+
+```jsonc
+{
+    "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+    "features": {
+        "ghcr.io/jsburckhardt/devcontainer-features/fzf:1": {}
+        "ghcr.io/jsburckhardt/devcontainer-features/lazygit:1": {}
+        "ghcr.io/jsburckhardt/devcontainer-features/ripgrep:1": {}
+        "ghcr.io/jsburckhardt/devcontainer-features/fd:1": {}
+        "ghcr.io/jsburckhardt/devcontainer-features/rtk:1": {}
+        "ghcr.io/jsburckhardt/devcontainer-features/zoxide:1": {}
+        "ghcr.io/jsburckhardt/devcontainer-features/hyperfine:1": {}
+        "ghcr.io/jsburckhardt/devcontainer-features/glow:1": {}
+        "ghcr.io/jsburckhardt/devcontainer-features/fx:1": {}
+        "ghcr.io/jsburckhardt/devcontainer-features/hurl:1": {}
+    }
+}
+```
+
+```bash
+fzf --version
+lazygit --version
+rg --version
+fd --version
+rtk --version
+zoxide --version
+hyperfine --version
+glow --version
+fx --version
+hurl --version
 ```

--- a/src/fd/devcontainer-feature.json
+++ b/src/fd/devcontainer-feature.json
@@ -1,0 +1,13 @@
+{
+    "name": "fd",
+    "id": "fd",
+    "version": "1.0.0",
+    "description": "A simple, fast and user-friendly alternative to 'find'.",
+    "options": {
+        "version": {
+            "type": "string",
+            "default": "latest",
+            "description": "Version of fd to install from GitHub releases e.g. v10.2.0"
+        }
+    }
+}

--- a/src/fd/install.sh
+++ b/src/fd/install.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+
+# Variables
+REPO_OWNER="sharkdp"
+REPO_NAME="fd"
+BINARY_NAME="fd"
+FD_VERSION="${VERSION:-"latest"}"
+GITHUB_API_REPO_URL="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases"
+
+set -e
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+# Checks if packages are installed and installs them if not
+check_packages() {
+    if ! dpkg -s "$@" >/dev/null 2>&1; then
+        if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+            echo "Running apt-get update..."
+            apt-get update -y
+        fi
+        apt-get -y install --no-install-recommends "$@"
+    fi
+}
+
+# Make sure we have curl and jq
+check_packages curl jq ca-certificates
+
+# Function to get the latest version from GitHub API
+get_latest_version() {
+    curl -s "${GITHUB_API_REPO_URL}/latest" | jq -r ".tag_name"
+}
+
+# Check if a version is passed as an argument
+if [ -z "$FD_VERSION" ] || [ "$FD_VERSION" == "latest" ]; then
+    # No version provided, get the latest version
+    FD_VERSION=$(get_latest_version)
+    echo "No version provided or 'latest' specified, installing the latest version: $FD_VERSION"
+else
+    echo "Installing version from environment variable: $FD_VERSION"
+fi
+
+# Determine the OS and architecture
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+
+case "$ARCH" in
+    x86_64)
+        ARCH="x86_64"
+        ;;
+    i686)
+        ARCH="i686"
+        ;;
+    aarch64)
+        ARCH="aarch64"
+        ;;
+    armv7l)
+        ARCH="arm-unknown"
+        ;;
+    *)
+        echo "Unsupported architecture: $ARCH"
+        exit 1
+        ;;
+esac
+
+case "$OS" in
+    linux)
+        OS="unknown-linux-gnu"
+        ;;
+    darwin)
+        OS="apple-darwin"
+        ;;
+    *)
+        echo "Unsupported OS: $OS"
+        exit 1
+        ;;
+esac
+
+# Construct the download URL
+DOWNLOAD_URL="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/${FD_VERSION}/fd-${FD_VERSION}-${ARCH}-${OS}.tar.gz"
+
+# Create a temporary directory for the download
+TMP_DIR=$(mktemp -d)
+cd "$TMP_DIR" || exit
+
+echo "Downloading fd from $DOWNLOAD_URL"
+curl -sSL "$DOWNLOAD_URL" -o "fd.tar.gz"
+
+# Extract the tarball
+echo "Extracting fd..."
+tar -xzf "fd.tar.gz"
+
+# Find the extracted directory (it should match the archive name pattern)
+EXTRACTED_DIR=$(find . -name "fd-${FD_VERSION}-*" -type d | head -1)
+if [ -z "$EXTRACTED_DIR" ]; then
+    echo "ERROR: Could not find extracted fd directory"
+    exit 1
+fi
+
+# Move the binary to /usr/local/bin
+echo "Installing fd..."
+mv "${EXTRACTED_DIR}/fd" /usr/local/bin/
+
+# Cleanup
+cd - || exit
+rm -rf "$TMP_DIR"
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+# Verify installation
+echo "Verifying installation..."
+fd --version
+
+echo "Done!"

--- a/src/fx/devcontainer-feature.json
+++ b/src/fx/devcontainer-feature.json
@@ -1,0 +1,13 @@
+{
+    "name": "fx",
+    "id": "fx",
+    "version": "1.0.0",
+    "description": "Terminal JSON viewer & processor",
+    "options": {
+        "version": {
+            "type": "string",
+            "default": "latest",
+            "description": "Version of fx to install from GitHub releases e.g. 39.2.0"
+        }
+    }
+}

--- a/src/fx/install.sh
+++ b/src/fx/install.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+
+# Variables
+REPO_OWNER="antonmedv"
+REPO_NAME="fx"
+BINARY_NAME="fx"
+FX_VERSION="${VERSION:-"latest"}"
+GITHUB_API_REPO_URL="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases"
+
+set -e
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+# Checks if packages are installed and installs them if not
+check_packages() {
+    if ! dpkg -s "$@" >/dev/null 2>&1; then
+        if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+            echo "Running apt-get update..."
+            apt-get update -y
+        fi
+        apt-get -y install --no-install-recommends "$@"
+    fi
+}
+
+# Make sure we have curl and jq
+check_packages curl jq ca-certificates
+
+# Function to get the latest version from GitHub API
+get_latest_version() {
+    curl -s "${GITHUB_API_REPO_URL}/latest" | jq -r ".tag_name"
+}
+
+# Check if a version is passed as an argument
+if [ -z "$FX_VERSION" ] || [ "$FX_VERSION" == "latest" ]; then
+    # No version provided, get the latest version
+    FX_VERSION=$(get_latest_version)
+    echo "No version provided or 'latest' specified, installing the latest version: $FX_VERSION"
+else
+    echo "Installing version from environment variable: $FX_VERSION"
+fi
+
+# Determine the OS and architecture
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+
+case "$ARCH" in
+    x86_64)
+        ARCH="amd64"
+        ;;
+    aarch64)
+        ARCH="arm64"
+        ;;
+    *)
+        echo "Unsupported architecture: $ARCH"
+        exit 1
+        ;;
+esac
+
+case "$OS" in
+    linux)
+        OS="linux"
+        ;;
+    darwin)
+        OS="darwin"
+        ;;
+    *)
+        echo "Unsupported OS: $OS"
+        exit 1
+        ;;
+esac
+
+# Construct the download URL
+# fx releases are plain binaries named fx_{os}_{arch}
+DOWNLOAD_URL="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/${FX_VERSION}/fx_${OS}_${ARCH}"
+
+# Create a temporary directory for the download
+TMP_DIR=$(mktemp -d)
+cd "$TMP_DIR" || exit
+
+echo "Downloading fx from $DOWNLOAD_URL"
+curl -sSL "$DOWNLOAD_URL" -o "fx"
+
+# Move the binary to /usr/local/bin
+echo "Installing fx..."
+chmod +x fx
+mv fx /usr/local/bin/
+
+# Cleanup
+cd - || exit
+rm -rf "$TMP_DIR"
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+# Verify installation
+echo "Verifying installation..."
+fx --version
+
+echo "Done!"

--- a/src/fzf/devcontainer-feature.json
+++ b/src/fzf/devcontainer-feature.json
@@ -1,0 +1,13 @@
+{
+    "name": "fzf",
+    "id": "fzf",
+    "version": "1.0.0",
+    "description": "A command-line fuzzy finder.",
+    "options": {
+        "version": {
+            "type": "string",
+            "default": "latest",
+            "description": "Version of fzf to install from GitHub releases e.g. v0.72.0"
+        }
+    }
+}

--- a/src/fzf/install.sh
+++ b/src/fzf/install.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+
+# Variables
+REPO_OWNER="junegunn"
+REPO_NAME="fzf"
+BINARY_NAME="fzf"
+FZF_VERSION="${VERSION:-"latest"}"
+GITHUB_API_REPO_URL="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases"
+
+set -e
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+# Checks if packages are installed and installs them if not
+check_packages() {
+    if ! dpkg -s "$@" >/dev/null 2>&1; then
+        if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+            echo "Running apt-get update..."
+            apt-get update -y
+        fi
+        apt-get -y install --no-install-recommends "$@"
+    fi
+}
+
+# Make sure we have curl and jq
+check_packages curl jq ca-certificates
+
+# Function to get the latest version from GitHub API
+get_latest_version() {
+    curl -s "${GITHUB_API_REPO_URL}/latest" | jq -r ".tag_name"
+}
+
+# Check if a version is passed as an argument
+if [ -z "$FZF_VERSION" ] || [ "$FZF_VERSION" == "latest" ]; then
+    # No version provided, get the latest version
+    FZF_VERSION=$(get_latest_version)
+    echo "No version provided or 'latest' specified, installing the latest version: $FZF_VERSION"
+else
+    echo "Installing version from environment variable: $FZF_VERSION"
+fi
+
+# Strip the leading 'v' for the download URL filename
+FZF_VERSION_NUMBER="${FZF_VERSION#v}"
+
+# Determine the OS and architecture
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+
+case "$ARCH" in
+    x86_64)
+        ARCH="amd64"
+        ;;
+    aarch64)
+        ARCH="arm64"
+        ;;
+    armv7l)
+        ARCH="armv7"
+        ;;
+    *)
+        echo "Unsupported architecture: $ARCH"
+        exit 1
+        ;;
+esac
+
+# Construct the download URL
+# Pattern: fzf-{VERSION_NUMBER}-{os}_{arch}.tar.gz
+DOWNLOAD_URL="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/${FZF_VERSION}/fzf-${FZF_VERSION_NUMBER}-${OS}_${ARCH}.tar.gz"
+
+# Create a temporary directory for the download
+TMP_DIR=$(mktemp -d)
+cd "$TMP_DIR" || exit
+
+echo "Downloading fzf from $DOWNLOAD_URL"
+curl -sSL "$DOWNLOAD_URL" -o "fzf.tar.gz"
+
+# Extract the tarball
+echo "Extracting fzf..."
+tar -xzf "fzf.tar.gz"
+
+# Move the binary to /usr/local/bin
+echo "Installing fzf..."
+mv fzf /usr/local/bin/
+chmod +x /usr/local/bin/fzf
+
+# Cleanup
+cd - || exit
+rm -rf "$TMP_DIR"
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+# Verify installation
+echo "Verifying installation..."
+fzf --version
+
+echo "Done!"

--- a/src/glow/devcontainer-feature.json
+++ b/src/glow/devcontainer-feature.json
@@ -1,0 +1,13 @@
+{
+    "name": "Glow",
+    "id": "glow",
+    "version": "1.0.0",
+    "description": "Render markdown on the CLI, with pizzazz! 💅🏻",
+    "options": {
+        "version": {
+            "type": "string",
+            "default": "latest",
+            "description": "Version of glow to install from GitHub releases e.g. v2.1.2"
+        }
+    }
+}

--- a/src/glow/install.sh
+++ b/src/glow/install.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+
+# Variables
+REPO_OWNER="charmbracelet"
+REPO_NAME="glow"
+BINARY_NAME="glow"
+GLOW_VERSION="${VERSION:-"latest"}"
+GITHUB_API_REPO_URL="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases"
+
+set -e
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+# Checks if packages are installed and installs them if not
+check_packages() {
+    if ! dpkg -s "$@" >/dev/null 2>&1; then
+        if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+            echo "Running apt-get update..."
+            apt-get update -y
+        fi
+        apt-get -y install --no-install-recommends "$@"
+    fi
+}
+
+# Make sure we have curl and jq
+check_packages curl jq ca-certificates
+
+# Function to get the latest version from GitHub API
+get_latest_version() {
+    curl -s "${GITHUB_API_REPO_URL}/latest" | jq -r ".tag_name"
+}
+
+# Check if a version is passed as an argument
+if [ -z "$GLOW_VERSION" ] || [ "$GLOW_VERSION" == "latest" ]; then
+    # No version provided, get the latest version
+    GLOW_VERSION=$(get_latest_version)
+    echo "No version provided or 'latest' specified, installing the latest version: $GLOW_VERSION"
+else
+    echo "Installing version from environment variable: $GLOW_VERSION"
+fi
+
+# Strip the leading 'v' for the download URL filename
+VERSION_NO_V="${GLOW_VERSION#v}"
+
+# Determine the OS and architecture
+OS=$(uname -s)
+ARCH=$(uname -m)
+
+case "$ARCH" in
+    x86_64)
+        ARCH="x86_64"
+        ;;
+    i686 | i386)
+        ARCH="i386"
+        ;;
+    aarch64 | arm64)
+        ARCH="arm64"
+        ;;
+    armv7l)
+        ARCH="arm"
+        ;;
+    *)
+        echo "Unsupported architecture: $ARCH"
+        exit 1
+        ;;
+esac
+
+case "$OS" in
+    Linux)
+        OS="Linux"
+        ;;
+    Darwin)
+        OS="Darwin"
+        ;;
+    *)
+        echo "Unsupported OS: $OS"
+        exit 1
+        ;;
+esac
+
+# Construct the download URL
+DOWNLOAD_URL="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/${GLOW_VERSION}/glow_${VERSION_NO_V}_${OS}_${ARCH}.tar.gz"
+
+# Create a temporary directory for the download
+TMP_DIR=$(mktemp -d)
+cd "$TMP_DIR" || exit
+
+echo "Downloading glow from $DOWNLOAD_URL"
+curl -sSL "$DOWNLOAD_URL" -o "glow.tar.gz"
+
+# Extract the tarball
+echo "Extracting glow..."
+tar -xzf "glow.tar.gz"
+
+# Find the extracted binary (tarball uses glow_VERSION_OS_ARCH/ directory)
+EXTRACTED_DIR=$(find . -name "glow_*" -type d | head -1)
+if [ -z "$EXTRACTED_DIR" ]; then
+    echo "ERROR: Could not find extracted glow directory"
+    exit 1
+fi
+
+# Move the binary to /usr/local/bin
+echo "Installing glow..."
+mv "${EXTRACTED_DIR}/glow" /usr/local/bin/
+chmod +x /usr/local/bin/glow
+
+# Cleanup
+cd - || exit
+rm -rf "$TMP_DIR"
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+# Verify installation
+echo "Verifying installation..."
+glow --version
+
+echo "Done!"

--- a/src/hurl/devcontainer-feature.json
+++ b/src/hurl/devcontainer-feature.json
@@ -1,0 +1,13 @@
+{
+    "name": "hurl",
+    "id": "hurl",
+    "version": "1.0.0",
+    "description": "Run and test HTTP requests with plain text.",
+    "options": {
+        "version": {
+            "type": "string",
+            "default": "latest",
+            "description": "Version of hurl to install from GitHub releases e.g. 8.0.1"
+        }
+    }
+}

--- a/src/hurl/install.sh
+++ b/src/hurl/install.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+
+# Variables
+REPO_OWNER="Orange-OpenSource"
+REPO_NAME="hurl"
+BINARY_NAME="hurl"
+HURL_VERSION="${VERSION:-"latest"}"
+GITHUB_API_REPO_URL="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases"
+
+set -e
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+# Checks if packages are installed and installs them if not
+check_packages() {
+    if ! dpkg -s "$@" >/dev/null 2>&1; then
+        if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+            echo "Running apt-get update..."
+            apt-get update -y
+        fi
+        apt-get -y install --no-install-recommends "$@"
+    fi
+}
+
+# Make sure we have curl, jq, and hurl runtime dependencies
+check_packages curl jq ca-certificates libxml2 libcurl4 libssl3
+
+# Function to get the latest version from GitHub API
+get_latest_version() {
+    curl -s "${GITHUB_API_REPO_URL}/latest" | jq -r ".tag_name"
+}
+
+# Check if a version is passed as an argument
+if [ -z "$HURL_VERSION" ] || [ "$HURL_VERSION" == "latest" ]; then
+    # No version provided, get the latest version
+    HURL_VERSION=$(get_latest_version)
+    echo "No version provided or 'latest' specified, installing the latest version: $HURL_VERSION"
+else
+    echo "Installing version from environment variable: $HURL_VERSION"
+fi
+
+# Determine the OS and architecture
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+
+case "$ARCH" in
+    x86_64)
+        ARCH="x86_64"
+        ;;
+    aarch64)
+        ARCH="aarch64"
+        ;;
+    *)
+        echo "Unsupported architecture: $ARCH"
+        exit 1
+        ;;
+esac
+
+case "$OS" in
+    linux)
+        OS="unknown-linux-gnu"
+        ;;
+    darwin)
+        OS="apple-darwin"
+        ;;
+    *)
+        echo "Unsupported OS: $OS"
+        exit 1
+        ;;
+esac
+
+# Construct the download URL
+DOWNLOAD_URL="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/${HURL_VERSION}/hurl-${HURL_VERSION}-${ARCH}-${OS}.tar.gz"
+
+# Create a temporary directory for the download
+TMP_DIR=$(mktemp -d)
+cd "$TMP_DIR" || exit
+
+echo "Downloading hurl from $DOWNLOAD_URL"
+curl -sSL "$DOWNLOAD_URL" -o "hurl.tar.gz"
+
+# Extract the tarball
+echo "Extracting hurl..."
+tar -xzf "hurl.tar.gz"
+
+# Find the extracted directory
+EXTRACTED_DIR=$(find . -name "hurl-${HURL_VERSION}-*" -type d | head -1)
+if [ -z "$EXTRACTED_DIR" ]; then
+    echo "ERROR: Could not find extracted hurl directory"
+    exit 1
+fi
+
+# Move the binaries to /usr/local/bin (hurl ships hurl and hurlfmt)
+echo "Installing hurl..."
+mv "${EXTRACTED_DIR}/bin/hurl" /usr/local/bin/
+mv "${EXTRACTED_DIR}/bin/hurlfmt" /usr/local/bin/
+
+# Cleanup
+cd - || exit
+rm -rf "$TMP_DIR"
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+# Verify installation
+echo "Verifying installation..."
+hurl --version
+
+echo "Done!"

--- a/src/hyperfine/devcontainer-feature.json
+++ b/src/hyperfine/devcontainer-feature.json
@@ -1,0 +1,13 @@
+{
+    "name": "hyperfine",
+    "id": "hyperfine",
+    "version": "1.0.0",
+    "description": "A command-line benchmarking tool.",
+    "options": {
+        "version": {
+            "type": "string",
+            "default": "latest",
+            "description": "Version of hyperfine to install from GitHub releases e.g. v1.20.0"
+        }
+    }
+}

--- a/src/hyperfine/install.sh
+++ b/src/hyperfine/install.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+
+# Variables
+REPO_OWNER="sharkdp"
+REPO_NAME="hyperfine"
+BINARY_NAME="hyperfine"
+HYPERFINE_VERSION="${VERSION:-"latest"}"
+GITHUB_API_REPO_URL="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases"
+
+set -e
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+# Checks if packages are installed and installs them if not
+check_packages() {
+    if ! dpkg -s "$@" >/dev/null 2>&1; then
+        if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+            echo "Running apt-get update..."
+            apt-get update -y
+        fi
+        apt-get -y install --no-install-recommends "$@"
+    fi
+}
+
+# Make sure we have curl and jq
+check_packages curl jq ca-certificates
+
+# Function to get the latest version from GitHub API
+get_latest_version() {
+    curl -s "${GITHUB_API_REPO_URL}/latest" | jq -r ".tag_name"
+}
+
+# Check if a version is passed as an argument
+if [ -z "$HYPERFINE_VERSION" ] || [ "$HYPERFINE_VERSION" == "latest" ]; then
+    # No version provided, get the latest version
+    HYPERFINE_VERSION=$(get_latest_version)
+    echo "No version provided or 'latest' specified, installing the latest version: $HYPERFINE_VERSION"
+else
+    echo "Installing version from environment variable: $HYPERFINE_VERSION"
+fi
+
+# Determine the OS and architecture
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+
+case "$ARCH" in
+    x86_64)
+        ARCH="x86_64"
+        ;;
+    i686)
+        ARCH="i686"
+        ;;
+    aarch64)
+        ARCH="aarch64"
+        ;;
+    armv7l)
+        ARCH="arm-unknown"
+        ;;
+    *)
+        echo "Unsupported architecture: $ARCH"
+        exit 1
+        ;;
+esac
+
+case "$OS" in
+    linux)
+        OS="unknown-linux-gnu"
+        ;;
+    darwin)
+        OS="apple-darwin"
+        ;;
+    *)
+        echo "Unsupported OS: $OS"
+        exit 1
+        ;;
+esac
+
+# Construct the download URL
+DOWNLOAD_URL="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/${HYPERFINE_VERSION}/hyperfine-${HYPERFINE_VERSION}-${ARCH}-${OS}.tar.gz"
+
+# Create a temporary directory for the download
+TMP_DIR=$(mktemp -d)
+cd "$TMP_DIR" || exit
+
+echo "Downloading hyperfine from $DOWNLOAD_URL"
+curl -sSL "$DOWNLOAD_URL" -o "hyperfine.tar.gz"
+
+# Extract the tarball
+echo "Extracting hyperfine..."
+tar -xzf "hyperfine.tar.gz"
+
+# Find the extracted directory (it should match the archive name pattern)
+EXTRACTED_DIR=$(find . -name "hyperfine-${HYPERFINE_VERSION}-*" -type d | head -1)
+if [ -z "$EXTRACTED_DIR" ]; then
+    echo "ERROR: Could not find extracted hyperfine directory"
+    exit 1
+fi
+
+# Move the binary to /usr/local/bin
+echo "Installing hyperfine..."
+mv "${EXTRACTED_DIR}/hyperfine" /usr/local/bin/
+
+# Cleanup
+cd - || exit
+rm -rf "$TMP_DIR"
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+# Verify installation
+echo "Verifying installation..."
+hyperfine --version
+
+echo "Done!"

--- a/src/lazygit/devcontainer-feature.json
+++ b/src/lazygit/devcontainer-feature.json
@@ -1,0 +1,13 @@
+{
+    "name": "lazygit",
+    "id": "lazygit",
+    "version": "1.0.0",
+    "description": "Simple terminal UI for git commands.",
+    "options": {
+        "version": {
+            "type": "string",
+            "default": "latest",
+            "description": "Version of lazygit to install from GitHub releases e.g. v0.61.1"
+        }
+    }
+}

--- a/src/lazygit/install.sh
+++ b/src/lazygit/install.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+
+# Variables
+REPO_OWNER="jesseduffield"
+REPO_NAME="lazygit"
+BINARY_NAME="lazygit"
+LAZYGIT_VERSION="${VERSION:-"latest"}"
+GITHUB_API_REPO_URL="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases"
+
+set -e
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+# Checks if packages are installed and installs them if not
+check_packages() {
+    if ! dpkg -s "$@" >/dev/null 2>&1; then
+        if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+            echo "Running apt-get update..."
+            apt-get update -y
+        fi
+        apt-get -y install --no-install-recommends "$@"
+    fi
+}
+
+# Make sure we have curl and jq
+check_packages curl jq ca-certificates
+
+# Function to get the latest version from GitHub API
+get_latest_version() {
+    curl -s "${GITHUB_API_REPO_URL}/latest" | jq -r ".tag_name"
+}
+
+# Check if a version is passed as an argument
+if [ -z "$LAZYGIT_VERSION" ] || [ "$LAZYGIT_VERSION" == "latest" ]; then
+    # No version provided, get the latest version
+    LAZYGIT_VERSION=$(get_latest_version)
+    echo "No version provided or 'latest' specified, installing the latest version: $LAZYGIT_VERSION"
+else
+    echo "Installing version from environment variable: $LAZYGIT_VERSION"
+fi
+
+# Strip the leading 'v' for the download URL (assets use version without 'v' prefix)
+VERSION_NO_V="${LAZYGIT_VERSION#v}"
+
+# Determine the OS and architecture
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+
+case "$ARCH" in
+    x86_64)
+        ARCH="x86_64"
+        ;;
+    aarch64)
+        ARCH="arm64"
+        ;;
+    armv7l)
+        ARCH="armv6"
+        ;;
+    i686)
+        ARCH="32-bit"
+        ;;
+    *)
+        echo "Unsupported architecture: $ARCH"
+        exit 1
+        ;;
+esac
+
+case "$OS" in
+    linux)
+        OS="Linux"
+        ;;
+    darwin)
+        OS="Darwin"
+        ;;
+    *)
+        echo "Unsupported OS: $OS"
+        exit 1
+        ;;
+esac
+
+# Construct the download URL
+# Pattern: lazygit_{VERSION_NO_V}_{OS}_{ARCH}.tar.gz
+DOWNLOAD_URL="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/${LAZYGIT_VERSION}/lazygit_${VERSION_NO_V}_${OS}_${ARCH}.tar.gz"
+
+# Create a temporary directory for the download
+TMP_DIR=$(mktemp -d)
+cd "$TMP_DIR" || exit
+
+echo "Downloading lazygit from $DOWNLOAD_URL"
+curl -sSL "$DOWNLOAD_URL" -o "lazygit.tar.gz"
+
+# Extract the tarball
+echo "Extracting lazygit..."
+tar -xzf "lazygit.tar.gz"
+
+# Move the binary to /usr/local/bin
+echo "Installing lazygit..."
+mv lazygit /usr/local/bin/
+chmod +x /usr/local/bin/lazygit
+
+# Cleanup
+cd - || exit
+rm -rf "$TMP_DIR"
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+# Verify installation
+echo "Verifying installation..."
+lazygit --version
+
+echo "Done!"

--- a/src/ripgrep/devcontainer-feature.json
+++ b/src/ripgrep/devcontainer-feature.json
@@ -1,0 +1,13 @@
+{
+    "name": "ripgrep",
+    "id": "ripgrep",
+    "version": "1.0.0",
+    "description": "Recursively searches directories for a regex pattern while respecting your gitignore.",
+    "options": {
+        "version": {
+            "type": "string",
+            "default": "latest",
+            "description": "Version of ripgrep to install from GitHub releases e.g. 14.1.1"
+        }
+    }
+}

--- a/src/ripgrep/install.sh
+++ b/src/ripgrep/install.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+
+# Variables
+REPO_OWNER="BurntSushi"
+REPO_NAME="ripgrep"
+BINARY_NAME="rg"
+RIPGREP_VERSION="${VERSION:-"latest"}"
+GITHUB_API_REPO_URL="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases"
+
+set -e
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+# Checks if packages are installed and installs them if not
+check_packages() {
+    if ! dpkg -s "$@" >/dev/null 2>&1; then
+        if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+            echo "Running apt-get update..."
+            apt-get update -y
+        fi
+        apt-get -y install --no-install-recommends "$@"
+    fi
+}
+
+# Make sure we have curl and jq
+check_packages curl jq ca-certificates
+
+# Function to get the latest version from GitHub API
+get_latest_version() {
+    curl -s "${GITHUB_API_REPO_URL}/latest" | jq -r ".tag_name"
+}
+
+# Check if a version is passed as an argument
+if [ -z "$RIPGREP_VERSION" ] || [ "$RIPGREP_VERSION" == "latest" ]; then
+    # No version provided, get the latest version
+    RIPGREP_VERSION=$(get_latest_version)
+    echo "No version provided or 'latest' specified, installing the latest version: $RIPGREP_VERSION"
+else
+    echo "Installing version from environment variable: $RIPGREP_VERSION"
+fi
+
+# Determine the OS and architecture
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+
+case "$ARCH" in
+    x86_64)
+        ARCH_TRIPLE="x86_64-unknown-linux-musl"
+        ;;
+    i686)
+        ARCH_TRIPLE="i686-unknown-linux-gnu"
+        ;;
+    aarch64)
+        ARCH_TRIPLE="aarch64-unknown-linux-gnu"
+        ;;
+    armv7l)
+        ARCH_TRIPLE="armv7-unknown-linux-gnueabihf"
+        ;;
+    *)
+        echo "Unsupported architecture: $ARCH"
+        exit 1
+        ;;
+esac
+
+case "$OS" in
+    linux)
+        # ARCH_TRIPLE already set above for linux
+        ;;
+    darwin)
+        case "$ARCH" in
+            x86_64)
+                ARCH_TRIPLE="x86_64-apple-darwin"
+                ;;
+            aarch64|arm64)
+                ARCH_TRIPLE="aarch64-apple-darwin"
+                ;;
+            *)
+                echo "Unsupported architecture on macOS: $ARCH"
+                exit 1
+                ;;
+        esac
+        ;;
+    *)
+        echo "Unsupported OS: $OS"
+        exit 1
+        ;;
+esac
+
+# Construct the download URL
+DOWNLOAD_URL="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/${RIPGREP_VERSION}/ripgrep-${RIPGREP_VERSION}-${ARCH_TRIPLE}.tar.gz"
+
+# Create a temporary directory for the download
+TMP_DIR=$(mktemp -d)
+cd "$TMP_DIR" || exit
+
+echo "Downloading ripgrep from $DOWNLOAD_URL"
+curl -sSL "$DOWNLOAD_URL" -o "ripgrep.tar.gz"
+
+# Extract the tarball
+echo "Extracting ripgrep..."
+tar -xzf "ripgrep.tar.gz"
+
+# Find the extracted directory
+EXTRACTED_DIR=$(find . -name "ripgrep-${RIPGREP_VERSION}-*" -type d | head -1)
+if [ -z "$EXTRACTED_DIR" ]; then
+    echo "ERROR: Could not find extracted ripgrep directory"
+    exit 1
+fi
+
+# Move the binary to /usr/local/bin
+echo "Installing ripgrep..."
+mv "${EXTRACTED_DIR}/rg" /usr/local/bin/
+
+# Cleanup
+cd - || exit
+rm -rf "$TMP_DIR"
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+# Verify installation
+echo "Verifying installation..."
+rg --version
+
+echo "Done!"

--- a/src/rtk/devcontainer-feature.json
+++ b/src/rtk/devcontainer-feature.json
@@ -1,0 +1,13 @@
+{
+    "name": "rtk",
+    "id": "rtk",
+    "version": "1.0.0",
+    "description": "CLI proxy that reduces LLM token consumption by 60-90% on common dev commands. Single Rust binary, zero dependencies.",
+    "options": {
+        "version": {
+            "type": "string",
+            "default": "latest",
+            "description": "Version of rtk to install from GitHub releases e.g. v0.38.0"
+        }
+    }
+}

--- a/src/rtk/install.sh
+++ b/src/rtk/install.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+
+# Variables
+REPO_OWNER="rtk-ai"
+REPO_NAME="rtk"
+BINARY_NAME="rtk"
+RTK_VERSION="${VERSION:-"latest"}"
+GITHUB_API_REPO_URL="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases"
+
+set -e
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+# Checks if packages are installed and installs them if not
+check_packages() {
+    if ! dpkg -s "$@" >/dev/null 2>&1; then
+        if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+            echo "Running apt-get update..."
+            apt-get update -y
+        fi
+        apt-get -y install --no-install-recommends "$@"
+    fi
+}
+
+# Make sure we have curl and jq
+check_packages curl jq ca-certificates
+
+# Function to get the latest version from GitHub API
+get_latest_version() {
+    curl -s "${GITHUB_API_REPO_URL}/latest" | jq -r ".tag_name"
+}
+
+# Check if a version is passed as an argument
+if [ -z "$RTK_VERSION" ] || [ "$RTK_VERSION" == "latest" ]; then
+    # No version provided, get the latest version
+    RTK_VERSION=$(get_latest_version)
+    echo "No version provided or 'latest' specified, installing the latest version: $RTK_VERSION"
+else
+    echo "Installing version from environment variable: $RTK_VERSION"
+fi
+
+# Determine the OS and architecture
+ARCH=$(uname -m)
+
+case "$ARCH" in
+    x86_64)
+        ARCH_TRIPLE="x86_64-unknown-linux-musl"
+        ;;
+    aarch64)
+        ARCH_TRIPLE="aarch64-unknown-linux-gnu"
+        ;;
+    *)
+        echo "Unsupported architecture: $ARCH"
+        exit 1
+        ;;
+esac
+
+# Construct the download URL
+DOWNLOAD_URL="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/${RTK_VERSION}/rtk-${ARCH_TRIPLE}.tar.gz"
+
+# Create a temporary directory for the download
+TMP_DIR=$(mktemp -d)
+cd "$TMP_DIR" || exit
+
+echo "Downloading rtk from $DOWNLOAD_URL"
+curl -sSL "$DOWNLOAD_URL" -o "rtk.tar.gz"
+
+# Extract the tarball
+echo "Extracting rtk..."
+tar -xzf "rtk.tar.gz"
+
+# Move the binary to /usr/local/bin
+echo "Installing rtk..."
+mv rtk /usr/local/bin/
+chmod +x /usr/local/bin/rtk
+
+# Cleanup
+cd - || exit
+rm -rf "$TMP_DIR"
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+# Verify installation
+echo "Verifying installation..."
+rtk --version
+
+echo "Done!"

--- a/src/zoxide/devcontainer-feature.json
+++ b/src/zoxide/devcontainer-feature.json
@@ -1,0 +1,13 @@
+{
+    "name": "zoxide",
+    "id": "zoxide",
+    "version": "1.0.0",
+    "description": "A smarter cd command. Supports all major shells.",
+    "options": {
+        "version": {
+            "type": "string",
+            "default": "latest",
+            "description": "Version of zoxide to install from GitHub releases e.g. v0.9.9"
+        }
+    }
+}

--- a/src/zoxide/install.sh
+++ b/src/zoxide/install.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+
+# Variables
+REPO_OWNER="ajeetdsouza"
+REPO_NAME="zoxide"
+BINARY_NAME="zoxide"
+ZOXIDE_VERSION="${VERSION:-"latest"}"
+GITHUB_API_REPO_URL="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases"
+
+set -e
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+# Checks if packages are installed and installs them if not
+check_packages() {
+    if ! dpkg -s "$@" >/dev/null 2>&1; then
+        if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+            echo "Running apt-get update..."
+            apt-get update -y
+        fi
+        apt-get -y install --no-install-recommends "$@"
+    fi
+}
+
+# Make sure we have curl and jq
+check_packages curl jq ca-certificates
+
+# Function to get the latest version from GitHub API
+get_latest_version() {
+    curl -s "${GITHUB_API_REPO_URL}/latest" | jq -r ".tag_name"
+}
+
+# Check if a version is passed as an argument
+if [ -z "$ZOXIDE_VERSION" ] || [ "$ZOXIDE_VERSION" == "latest" ]; then
+    # No version provided, get the latest version
+    ZOXIDE_VERSION=$(get_latest_version)
+    echo "No version provided or 'latest' specified, installing the latest version: $ZOXIDE_VERSION"
+else
+    echo "Installing version from environment variable: $ZOXIDE_VERSION"
+fi
+
+# Strip the leading 'v' for the download URL filename
+VERSION_NO_V="${ZOXIDE_VERSION#v}"
+
+# Determine the OS and architecture
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+
+case "$ARCH" in
+    x86_64)
+        ARCH="x86_64"
+        ;;
+    i686)
+        ARCH="i686"
+        ;;
+    aarch64)
+        ARCH="aarch64"
+        ;;
+    armv7l)
+        ARCH="armv7"
+        ;;
+    *)
+        echo "Unsupported architecture: $ARCH"
+        exit 1
+        ;;
+esac
+
+case "$OS" in
+    linux)
+        OS="unknown-linux-musl"
+        ;;
+    darwin)
+        OS="apple-darwin"
+        ;;
+    *)
+        echo "Unsupported OS: $OS"
+        exit 1
+        ;;
+esac
+
+# Construct the download URL
+DOWNLOAD_URL="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/${ZOXIDE_VERSION}/zoxide-${VERSION_NO_V}-${ARCH}-${OS}.tar.gz"
+
+# Create a temporary directory for the download
+TMP_DIR=$(mktemp -d)
+cd "$TMP_DIR" || exit
+
+echo "Downloading zoxide from $DOWNLOAD_URL"
+curl -sSL "$DOWNLOAD_URL" -o "zoxide.tar.gz"
+
+# Extract the tarball
+echo "Extracting zoxide..."
+tar -xzf "zoxide.tar.gz"
+
+# Move the binary to /usr/local/bin
+echo "Installing zoxide..."
+mv zoxide /usr/local/bin/
+chmod +x /usr/local/bin/zoxide
+
+# Cleanup
+cd - || exit
+rm -rf "$TMP_DIR"
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+# Verify installation
+echo "Verifying installation..."
+zoxide --version
+
+echo "Done!"

--- a/test/_global/all-tools.sh
+++ b/test/_global/all-tools.sh
@@ -21,5 +21,15 @@ check "opencode" opencode --version
 check "ccc" ccc --version
 check "yazi" yazi --version
 check "tmux" tmux -V
+check "fzf" fzf --version
+check "lazygit" lazygit --version
+check "ripgrep" rg --version
+check "fd" fd --version
+check "rtk" rtk --version
+check "zoxide" zoxide --version
+check "hyperfine" hyperfine --version
+check "glow" glow --version
+check "fx" fx --version
+check "hurl" hurl --version
 
 reportResults

--- a/test/_global/fd-specific-version.sh
+++ b/test/_global/fd-specific-version.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+source dev-container-features-test-lib
+check "fd with specific version" /bin/bash -c "fd --version | grep '10.2.0'"
+
+reportResults

--- a/test/_global/fx-specific-version.sh
+++ b/test/_global/fx-specific-version.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+source dev-container-features-test-lib
+check "fx with specific version" /bin/bash -c "fx --version | grep '35.0.0'"
+
+reportResults

--- a/test/_global/fzf-specific-version.sh
+++ b/test/_global/fzf-specific-version.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+source dev-container-features-test-lib
+check "fzf with specific version" /bin/bash -c "fzf --version | grep '0.58.0'"
+
+reportResults

--- a/test/_global/glow-specific-version.sh
+++ b/test/_global/glow-specific-version.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+source dev-container-features-test-lib
+check "glow with specific version" /bin/bash -c "glow --version | grep '2.1.2'"
+
+reportResults

--- a/test/_global/hurl-specific-version.sh
+++ b/test/_global/hurl-specific-version.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+source dev-container-features-test-lib
+check "hurl with specific version" /bin/bash -c "hurl --version | grep '6.0.0'"
+
+reportResults

--- a/test/_global/hyperfine-specific-version.sh
+++ b/test/_global/hyperfine-specific-version.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+source dev-container-features-test-lib
+check "hyperfine with specific version" /bin/bash -c "hyperfine --version | grep '1.19.0'"
+
+reportResults

--- a/test/_global/lazygit-specific-version.sh
+++ b/test/_global/lazygit-specific-version.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+source dev-container-features-test-lib
+check "lazygit with specific version" /bin/bash -c "lazygit --version | grep '0.44.0'"
+
+reportResults

--- a/test/_global/ripgrep-specific-version.sh
+++ b/test/_global/ripgrep-specific-version.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+source dev-container-features-test-lib
+check "ripgrep with specific version" /bin/bash -c "rg --version | grep '14.1.1'"
+
+reportResults

--- a/test/_global/rtk-specific-version.sh
+++ b/test/_global/rtk-specific-version.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+source dev-container-features-test-lib
+check "rtk with specific version" /bin/bash -c "rtk --version | grep '0.38.0'"
+
+reportResults

--- a/test/_global/scenarios.json
+++ b/test/_global/scenarios.json
@@ -22,7 +22,17 @@
             "opencode": {},
             "ccc": {},
             "yazi": {},
-            "tmux": {}
+            "tmux": {},
+            "hurl": {},
+            "fzf": {},
+            "lazygit": {},
+            "ripgrep": {},
+            "fd": {},
+            "rtk": {},
+            "zoxide": {},
+            "hyperfine": {},
+            "glow": {},
+            "fx": {}
         }
     },
     "flux-specific-version": {
@@ -171,6 +181,86 @@
         "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
         "features": {
             "tmux": {}
+        }
+    },
+    "hurl-specific-version": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "hurl": {
+                "version": "6.0.0"
+            }
+        }
+    },
+    "fzf-specific-version": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "fzf": {
+                "version": "v0.58.0"
+            }
+        }
+    },
+    "lazygit-specific-version": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "lazygit": {
+                "version": "v0.44.0"
+            }
+        }
+    },
+    "ripgrep-specific-version": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "ripgrep": {
+                "version": "14.1.1"
+            }
+        }
+    },
+    "fd-specific-version": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "fd": {
+                "version": "v10.2.0"
+            }
+        }
+    },
+    "rtk-specific-version": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "rtk": {
+                "version": "v0.38.0"
+            }
+        }
+    },
+    "zoxide-specific-version": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "zoxide": {
+                "version": "v0.9.6"
+            }
+        }
+    },
+    "hyperfine-specific-version": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "hyperfine": {
+                "version": "v1.19.0"
+            }
+        }
+    },
+    "glow-specific-version": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "glow": {
+                "version": "v2.1.2"
+            }
+        }
+    },
+    "fx-specific-version": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "fx": {
+                "version": "35.0.0"
+            }
         }
     }
 }

--- a/test/_global/zoxide-specific-version.sh
+++ b/test/_global/zoxide-specific-version.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+source dev-container-features-test-lib
+check "zoxide with specific version" /bin/bash -c "zoxide --version | grep '0.9.6'"
+
+reportResults

--- a/test/fd/test.sh
+++ b/test/fd/test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+source dev-container-features-test-lib
+check "fd" fd --version
+reportResults

--- a/test/fx/test.sh
+++ b/test/fx/test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+source dev-container-features-test-lib
+check "fx" fx --version
+reportResults

--- a/test/fzf/test.sh
+++ b/test/fzf/test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+source dev-container-features-test-lib
+check "fzf" fzf --version
+reportResults

--- a/test/glow/test.sh
+++ b/test/glow/test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+source dev-container-features-test-lib
+check "glow" glow --version
+reportResults

--- a/test/hurl/test.sh
+++ b/test/hurl/test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+source dev-container-features-test-lib
+check "hurl" hurl --version
+reportResults

--- a/test/hyperfine/test.sh
+++ b/test/hyperfine/test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+source dev-container-features-test-lib
+check "hyperfine" hyperfine --version
+reportResults

--- a/test/lazygit/test.sh
+++ b/test/lazygit/test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+source dev-container-features-test-lib
+check "lazygit" lazygit --version
+reportResults

--- a/test/ripgrep/test.sh
+++ b/test/ripgrep/test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+source dev-container-features-test-lib
+check "ripgrep" rg --version
+reportResults

--- a/test/rtk/test.sh
+++ b/test/rtk/test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+source dev-container-features-test-lib
+check "rtk" rtk --version
+reportResults

--- a/test/zoxide/test.sh
+++ b/test/zoxide/test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+source dev-container-features-test-lib
+check "zoxide" zoxide --version
+reportResults


### PR DESCRIPTION
## New Features

Adds 10 new devcontainer features, each installing a popular CLI tool from GitHub releases:

| Feature | Tool | Repo | Stars |
|---------|------|------|-------|
| **fzf** | Command-line fuzzy finder | junegunn/fzf | 80k ⭐ |
| **lazygit** | Terminal UI for git | jesseduffield/lazygit | 77k ⭐ |
| **ripgrep** | Fast regex search | BurntSushi/ripgrep | 63k ⭐ |
| **fd** | Modern find alternative | sharkdp/fd | 43k ⭐ |
| **rtk** | LLM token reduction proxy | rtk-ai/rtk | 40k ⭐ |
| **zoxide** | Smarter cd command | ajeetdsouza/zoxide | 36k ⭐ |
| **hyperfine** | CLI benchmarking tool | sharkdp/hyperfine | 28k ⭐ |
| **glow** | Markdown renderer | charmbracelet/glow | 25k ⭐ |
| **fx** | Terminal JSON viewer | antonmedv/fx | 20k ⭐ |
| **hurl** | HTTP request runner/tester | Orange-OpenSource/hurl | 19k ⭐ |

Each feature includes:
- `devcontainer-feature.json` with version option (default: latest)
- `install.sh` following repo conventions (GitHub releases, multi-arch)
- Smoke test (`test/<feature>/test.sh`)
- Version-pinned global test (`test/_global/<feature>-specific-version.sh`)
- Updates to `all-tools.sh`, `scenarios.json`, CI workflow, and README

Closes #93, #94, #95, #96, #97, #98, #99, #100, #101, #102