### PR TITLE
feat(tmux): install from GitHub releases instead of apt

### DIFF
--- a/src/tmux/devcontainer-feature.json
+++ b/src/tmux/devcontainer-feature.json
@@ -1,13 +1,13 @@
 {
     "name": "tmux",
     "id": "tmux",
-    "version": "1.0.0",
+    "version": "2.0.0",
     "description": "tmux is a terminal multiplexer. It lets you switch easily between several programs in one terminal.",
     "options": {
         "version": {
             "type": "string",
-            "default": "os-provided",
-            "description": "Version of tmux to install (installs the version provided by the OS package manager)"
+            "default": "latest",
+            "description": "Version of tmux to install from GitHub releases (e.g. '3.6a', 'latest')"
         }
     }
 }

--- a/src/tmux/install.sh
+++ b/src/tmux/install.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+# Variables
+REPO_OWNER="tmux"
+REPO_NAME="tmux"
+BINARY_NAME="tmux"
+TMUX_VERSION="${VERSION:-"latest"}"
+GITHUB_API_REPO_URL="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases"
+
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
@@ -21,9 +28,48 @@ check_packages() {
     fi
 }
 
-# Install tmux
+# Make sure we have required dependencies
+check_packages curl jq ca-certificates build-essential pkg-config libevent-dev libncurses-dev bison tar
+
+# Function to get the latest version from GitHub API
+get_latest_version() {
+    curl -s "${GITHUB_API_REPO_URL}/latest" | jq -r ".tag_name"
+}
+
+# Check if a version is passed as an argument
+if [ -z "$TMUX_VERSION" ] || [ "$TMUX_VERSION" == "latest" ]; then
+    TMUX_VERSION=$(get_latest_version)
+    echo "No version provided or 'latest' specified, installing the latest version: $TMUX_VERSION"
+else
+    echo "Installing version from environment variable: $TMUX_VERSION"
+fi
+
+# Construct the download URL
+DOWNLOAD_URL="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/${TMUX_VERSION}/tmux-${TMUX_VERSION}.tar.gz"
+
+# Create a temporary directory for the download
+TMP_DIR=$(mktemp -d)
+cd "$TMP_DIR" || exit
+
+echo "Downloading tmux from $DOWNLOAD_URL"
+curl -sSL "$DOWNLOAD_URL" -o "tmux.tar.gz"
+
+# Extract the tarball
+echo "Extracting tmux..."
+tar -xzf "tmux.tar.gz"
+
+# Build from source
+cd "tmux-${TMUX_VERSION}" || exit
+echo "Configuring tmux..."
+./configure --prefix=/usr/local
+echo "Building tmux..."
+make -j"$(nproc)"
 echo "Installing tmux..."
-check_packages tmux
+make install
+
+# Cleanup
+cd / || exit
+rm -rf "$TMP_DIR"
 
 # Clean up
 rm -rf /var/lib/apt/lists/*

--- a/test/_global/scenarios.json
+++ b/test/_global/scenarios.json
@@ -170,7 +170,9 @@
     "tmux-specific-version": {
         "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
         "features": {
-            "tmux": {}
+            "tmux": {
+                "version": "3.6a"
+            }
         }
     }
 }

--- a/test/_global/tmux-specific-version.sh
+++ b/test/_global/tmux-specific-version.sh
@@ -2,6 +2,6 @@
 
 set -e
 source dev-container-features-test-lib
-check "tmux is installed" /bin/bash -c "tmux -V"
+check "tmux with specific version" /bin/bash -c "tmux -V | grep '3.6a'"
 
 reportResults


### PR DESCRIPTION
## Summary

Rewrites the tmux feature installer to build from GitHub release source tarballs instead of relying on apt packages. This allows installing the latest tmux versions (e.g. 3.6a) that aren't available in distro repos.

## Changes

- **install.sh** — Downloads source tarball from `github.com/tmux/tmux/releases`, compiles with `./configure && make && make install`. Build deps: `build-essential`, `pkg-config`, `libevent-dev`, `libncurses-dev`, `bison`.
- **devcontainer-feature.json** — Bumped to v2.0.0, default version changed from `os-provided` to `latest`.
- **scenarios.json** — Updated tmux-specific-version scenario to pin `3.6a`.
- **tmux-specific-version.sh** — Verifies version string `3.6a`.

## Testing

- `devcontainer features test -f tmux -i ubuntu:latest` ✅
- `devcontainer features test --global-scenarios-only --filter tmux-specific-version .` ✅

## Breaking Change

Version option default changed from `os-provided` to `latest` (now installs from releases by default).