### PR TITLE
fix: GitHub API rate-limiting

### DIFF
--- a/src/bat/install.sh
+++ b/src/bat/install.sh
@@ -5,8 +5,6 @@ REPO_OWNER="sharkdp"
 REPO_NAME="bat"
 BINARY_NAME="bat"
 BAT_VERSION="${VERSION:-"latest"}"
-GITHUB_API_REPO_URL="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases"
-
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
@@ -28,12 +26,13 @@ check_packages() {
     fi
 }
 
-# Make sure we have curl and jq
-check_packages curl jq ca-certificates
+# Make sure we have curl
+check_packages curl ca-certificates
 
-# Function to get the latest version from GitHub API
+# Function to get the latest version by following the GitHub releases redirect
 get_latest_version() {
-    curl -s "${GITHUB_API_REPO_URL}/latest" | jq -r ".tag_name"
+    curl -sI "https://github.com/$REPO_OWNER/$REPO_NAME/releases/latest" \
+        | grep -i '^location:' | sed 's|.*/tag/||;s/\r//'
 }
 
 # Check if a version is passed as an argument

--- a/src/ccc/install.sh
+++ b/src/ccc/install.sh
@@ -5,8 +5,6 @@ REPO_OWNER="jsburckhardt"
 REPO_NAME="co-config"
 BINARY_NAME="ccc"
 CCC_VERSION="${VERSION:-"latest"}"
-GITHUB_API_REPO_URL="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases"
-
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
@@ -28,12 +26,13 @@ check_packages() {
     fi
 }
 
-# Make sure we have curl and jq
-check_packages curl jq ca-certificates tar
+# Make sure we have curl
+check_packages curl ca-certificates tar
 
-# Function to get the latest version from GitHub API
+# Function to get the latest version by following the GitHub releases redirect
 get_latest_version() {
-    curl -s "${GITHUB_API_REPO_URL}/latest" | jq -r ".tag_name"
+    curl -sI "https://github.com/$REPO_OWNER/$REPO_NAME/releases/latest" \
+        | grep -i '^location:' | sed 's|.*/tag/||;s/\r//'
 }
 
 # Check if a version is passed as an argument

--- a/src/copa/install.sh
+++ b/src/copa/install.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
 COPA_VERSION="${VERSION:-"latest"}"
-GITHUB_API_REPO_URL="https://api.github.com/repos/project-copacetic/copacetic/releases"
+REPO_OWNER="project-copacetic"
+REPO_NAME="copacetic"
 URL_RELEASES="https://github.com/project-copacetic/copacetic/releases"
 
 set -e
@@ -46,26 +47,15 @@ check_packages() {
 	fi
 }
 
-# Figure out correct version of a three part version number is not passed
-validate_version_exists() {
-	local variable_name=$1
-    local requested_version=$2
-	if [ "${requested_version}" = "latest" ]; then requested_version=$(curl -sL ${GITHUB_API_REPO_URL}/latest | jq -r ".tag_name"); fi
-	local version_list
-    version_list=$(curl -sL ${GITHUB_API_REPO_URL} | jq -r ".[].tag_name")
-	if [ -z "${variable_name}" ] || ! echo "${version_list}" | grep "${requested_version}" >/dev/null 2>&1; then
-		echo -e "Invalid ${variable_name} value: ${requested_version}\nValid values:\n${version_list}" >&2
-		exit 1
-	fi
-	echo "${variable_name}=${requested_version}"
-}
-
 # make sure we have curl
-check_packages curl tar jq ca-certificates
+check_packages curl tar ca-certificates
 
-# make sure version is available
-if [ "${COPA_VERSION}" = "latest" ]; then COPA_VERSION=$(curl -sL ${GITHUB_API_REPO_URL}/latest | jq -r ".tag_name"); fi
-validate_version_exists COPA_VERSION "${COPA_VERSION}"
+# get latest version via redirect if not specified
+if [ "${COPA_VERSION}" = "latest" ]; then
+    COPA_VERSION=$(curl -sI "https://github.com/$REPO_OWNER/$REPO_NAME/releases/latest" \
+        | grep -i '^location:' | sed 's|.*/tag/||;s/\r//')
+    echo "No version provided or 'latest' specified, installing the latest version: $COPA_VERSION"
+fi
 
 # create COPA_VERSION_NUMBER (remove v from version COPA_VERSION if it has it)
 COPA_VERSION_NUMBER=$(echo "${COPA_VERSION}" | sed 's/v//g')

--- a/src/crane/install.sh
+++ b/src/crane/install.sh
@@ -44,26 +44,11 @@ check_packages() {
 	fi
 }
 
-# Figure out correct version of a three part version number is not passed
-validate_version_exists() {
-	local variable_name=$1
-    local requested_version=$2
-	if [ "${requested_version}" = "latest" ]; then requested_version=$(curl -sL https://api.github.com/repos/google/go-containerregistry/releases/latest | jq -r ".tag_name"); fi
-	local version_list
-    version_list=$(curl -sL https://api.github.com/repos/google/go-containerregistry/releases | jq -r ".[].tag_name")
-	if [ -z "${variable_name}" ] || ! echo "${version_list}" | grep "${requested_version}" >/dev/null 2>&1; then
-		echo -e "Invalid ${variable_name} value: ${requested_version}\nValid values:\n${version_list}" >&2
-		exit 1
-	fi
-	echo "${variable_name}=${requested_version}"
-}
-
 # make sure we have curl
-check_packages curl tar jq ca-certificates
+check_packages curl tar ca-certificates
 
 # make sure version is available
-if [ "${CRANE_VERSION}" = "latest" ]; then CRANE_VERSION=$(curl -sL https://api.github.com/repos/google/go-containerregistry/releases/latest | jq -r ".tag_name"); fi
-validate_version_exists CRANE_VERSION "${CRANE_VERSION}"
+if [ "${CRANE_VERSION}" = "latest" ]; then CRANE_VERSION=$(curl -sI "https://github.com/google/go-containerregistry/releases/latest" | grep -i '^location:' | sed 's|.*/tag/||;s/\r//'); fi
 
 # download and install binary
 CRANE_FILENAME=go-containerregistry_${OS}_${ARCH}.tar.gz

--- a/src/cyclonedx/install.sh
+++ b/src/cyclonedx/install.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
 CYCLONEDX_VERSION="${VERSION:-"latest"}"
-GITHUB_API_REPO_URL="https://api.github.com/repos/CycloneDX/cyclonedx-cli/releases"
+REPO_OWNER="CycloneDX"
+REPO_NAME="cyclonedx-cli"
 URL_RELEASES="https://github.com/CycloneDX/cyclonedx-cli/releases"
 
 set -e
@@ -47,26 +48,15 @@ check_packages() {
 	fi
 }
 
-# Figure out correct version of a three part version number is not passed
-validate_version_exists() {
-	local variable_name=$1
-    local requested_version=$2
-	if [ "${requested_version}" = "latest" ]; then requested_version=$(curl -sL ${GITHUB_API_REPO_URL}/latest | jq -r ".tag_name"); fi
-	local version_list
-    version_list=$(curl -sL ${GITHUB_API_REPO_URL} | jq -r ".[].tag_name")
-	if [ -z "${variable_name}" ] || ! echo "${version_list}" | grep "${requested_version}" >/dev/null 2>&1; then
-		echo -e "Invalid ${variable_name} value: ${requested_version}\nValid values:\n${version_list}" >&2
-		exit 1
-	fi
-	echo "${variable_name}=${requested_version}"
-}
-
 # make sure we have curl
-check_packages curl tar jq ca-certificates libicu-dev
+check_packages curl tar ca-certificates libicu-dev
 
-# make sure version is available
-if [ "${CYCLONEDX_VERSION}" = "latest" ]; then CYCLONEDX_VERSION=$(curl -sL ${GITHUB_API_REPO_URL}/latest | jq -r ".tag_name"); fi
-validate_version_exists CYCLONEDX_VERSION "${CYCLONEDX_VERSION}"
+# get latest version via redirect if not specified
+if [ "${CYCLONEDX_VERSION}" = "latest" ]; then
+    CYCLONEDX_VERSION=$(curl -sI "https://github.com/$REPO_OWNER/$REPO_NAME/releases/latest" \
+        | grep -i '^location:' | sed 's|.*/tag/||;s/\r//')
+    echo "No version provided or 'latest' specified, installing the latest version: $CYCLONEDX_VERSION"
+fi
 
 # download and install binary
 CYCLONEDX_FILENAME=cyclonedx-${OS}-${ARCH}

--- a/src/fd/install.sh
+++ b/src/fd/install.sh
@@ -5,8 +5,6 @@ REPO_OWNER="sharkdp"
 REPO_NAME="fd"
 BINARY_NAME="fd"
 FD_VERSION="${VERSION:-"latest"}"
-GITHUB_API_REPO_URL="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases"
-
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
@@ -28,12 +26,13 @@ check_packages() {
     fi
 }
 
-# Make sure we have curl and jq
-check_packages curl jq ca-certificates
+# Make sure we have curl
+check_packages curl ca-certificates
 
-# Function to get the latest version from GitHub API
+# Function to get the latest version by following the GitHub releases redirect
 get_latest_version() {
-    curl -s "${GITHUB_API_REPO_URL}/latest" | jq -r ".tag_name"
+    curl -sI "https://github.com/$REPO_OWNER/$REPO_NAME/releases/latest" \
+        | grep -i '^location:' | sed 's|.*/tag/||;s/\r//'
 }
 
 # Check if a version is passed as an argument

--- a/src/flux/install.sh
+++ b/src/flux/install.sh
@@ -35,26 +35,11 @@ check_packages() {
 	fi
 }
 
-# Figure out correct version of a three part version number is not passed
-validate_version_exists() {
-	local variable_name=$1
-    local requested_version=$2
-	if [ "${requested_version}" = "latest" ]; then requested_version=$(curl -sL https://api.github.com/repos/fluxcd/flux2/releases/latest | jq -r ".tag_name"); fi
-	local version_list
-    version_list=$(curl -sL https://api.github.com/repos/fluxcd/flux2/releases | jq -r ".[].tag_name")
-	if [ -z "${variable_name}" ] || ! echo "${version_list}" | grep "${requested_version}" >/dev/null 2>&1; then
-		echo -e "Invalid ${variable_name} value: ${requested_version}\nValid values:\n${version_list}" >&2
-		exit 1
-	fi
-	echo "${variable_name}=${requested_version}"
-}
-
 # make sure we have curl
-check_packages curl tar jq ca-certificates
+check_packages curl tar ca-certificates
 
 # make sure version is available
-if [ "${FLUX2_VERSION}" = "latest" ]; then FLUX2_VERSION=$(curl -sL https://api.github.com/repos/fluxcd/flux2/releases/latest | jq -r ".tag_name"); fi
-validate_version_exists FLUX2_VERSION "${FLUX2_VERSION}"
+if [ "${FLUX2_VERSION}" = "latest" ]; then FLUX2_VERSION=$(curl -sI "https://github.com/fluxcd/flux2/releases/latest" | grep -i '^location:' | sed 's|.*/tag/||;s/\r//'); fi
 
 # download and install binary
 FLUX2_FILENAME=flux_${FLUX2_VERSION:1}_linux_${architecture}.tar.gz

--- a/src/fx/install.sh
+++ b/src/fx/install.sh
@@ -5,8 +5,6 @@ REPO_OWNER="antonmedv"
 REPO_NAME="fx"
 BINARY_NAME="fx"
 FX_VERSION="${VERSION:-"latest"}"
-GITHUB_API_REPO_URL="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases"
-
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
@@ -28,12 +26,13 @@ check_packages() {
     fi
 }
 
-# Make sure we have curl and jq
-check_packages curl jq ca-certificates
+# Make sure we have curl
+check_packages curl ca-certificates
 
-# Function to get the latest version from GitHub API
+# Function to get the latest version by following the GitHub releases redirect
 get_latest_version() {
-    curl -s "${GITHUB_API_REPO_URL}/latest" | jq -r ".tag_name"
+    curl -sI "https://github.com/$REPO_OWNER/$REPO_NAME/releases/latest" \
+        | grep -i '^location:' | sed 's|.*/tag/||;s/\r//'
 }
 
 # Check if a version is passed as an argument

--- a/src/fzf/install.sh
+++ b/src/fzf/install.sh
@@ -5,8 +5,6 @@ REPO_OWNER="junegunn"
 REPO_NAME="fzf"
 BINARY_NAME="fzf"
 FZF_VERSION="${VERSION:-"latest"}"
-GITHUB_API_REPO_URL="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases"
-
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
@@ -28,12 +26,13 @@ check_packages() {
     fi
 }
 
-# Make sure we have curl and jq
-check_packages curl jq ca-certificates
+# Make sure we have curl
+check_packages curl ca-certificates
 
-# Function to get the latest version from GitHub API
+# Function to get the latest version by following the GitHub releases redirect
 get_latest_version() {
-    curl -s "${GITHUB_API_REPO_URL}/latest" | jq -r ".tag_name"
+    curl -sI "https://github.com/$REPO_OWNER/$REPO_NAME/releases/latest" \
+        | grep -i '^location:' | sed 's|.*/tag/||;s/\r//'
 }
 
 # Check if a version is passed as an argument

--- a/src/gic/install.sh
+++ b/src/gic/install.sh
@@ -28,10 +28,10 @@ check_packages() {
 # make sure we have packages
 check_packages curl tar jq ca-certificates
 
-# Function to get the latest version from GitHub API
+# Function to get the latest version by following the GitHub releases redirect
 get_latest_version() {
-    LATEST_URL="https://api.github.com/repos/$REPO_OWNER/$REPO_NAME/releases/latest"
-    curl -s "$LATEST_URL" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'
+    curl -sI "https://github.com/$REPO_OWNER/$REPO_NAME/releases/latest" \
+        | grep -i '^location:' | sed 's|.*/tag/||;s/\r//'
 }
 
 # Check if a version is provided via environment variable or passed as an argument

--- a/src/gitleaks/install.sh
+++ b/src/gitleaks/install.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
 GITLEAKS_VERSION="${VERSION:-"latest"}"
-GITHUB_API_REPO_URL="https://api.github.com/repos/gitleaks/gitleaks/releases"
+REPO_OWNER="gitleaks"
+REPO_NAME="gitleaks"
 URL_RELEASES="https://github.com/gitleaks/gitleaks/releases"
 
 set -e
@@ -46,26 +47,15 @@ check_packages() {
 	fi
 }
 
-# Figure out correct version of a three part version number is not passed
-validate_version_exists() {
-	local variable_name=$1
-    local requested_version=$2
-	if [ "${requested_version}" = "latest" ]; then requested_version=$(curl -sL ${GITHUB_API_REPO_URL}/latest | jq -r ".tag_name"); fi
-	local version_list
-    version_list=$(curl -sL ${GITHUB_API_REPO_URL} | jq -r ".[].tag_name")
-	if [ -z "${variable_name}" ] || ! echo "${version_list}" | grep "${requested_version}" >/dev/null 2>&1; then
-		echo -e "Invalid ${variable_name} value: ${requested_version}\nValid values:\n${version_list}" >&2
-		exit 1
-	fi
-	echo "${variable_name}=${requested_version}"
-}
-
 # make sure we have curl
-check_packages curl tar jq ca-certificates
+check_packages curl tar ca-certificates
 
-# make sure version is available
-if [ "${GITLEAKS_VERSION}" = "latest" ]; then GITLEAKS_VERSION=$(curl -sL ${GITHUB_API_REPO_URL}/latest | jq -r ".tag_name"); fi
-validate_version_exists GITLEAKS_VERSION "${GITLEAKS_VERSION}"
+# get latest version via redirect if not specified
+if [ "${GITLEAKS_VERSION}" = "latest" ]; then
+    GITLEAKS_VERSION=$(curl -sI "https://github.com/$REPO_OWNER/$REPO_NAME/releases/latest" \
+        | grep -i '^location:' | sed 's|.*/tag/||;s/\r//')
+    echo "No version provided or 'latest' specified, installing the latest version: $GITLEAKS_VERSION"
+fi
 
 # download and install binary
 GITLEAKS_FILENAME=gitleaks_${GITLEAKS_VERSION#v}_${OS}_${architecture}.tar.gz

--- a/src/glow/install.sh
+++ b/src/glow/install.sh
@@ -5,8 +5,6 @@ REPO_OWNER="charmbracelet"
 REPO_NAME="glow"
 BINARY_NAME="glow"
 GLOW_VERSION="${VERSION:-"latest"}"
-GITHUB_API_REPO_URL="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases"
-
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
@@ -28,12 +26,13 @@ check_packages() {
     fi
 }
 
-# Make sure we have curl and jq
-check_packages curl jq ca-certificates
+# Make sure we have curl
+check_packages curl ca-certificates
 
-# Function to get the latest version from GitHub API
+# Function to get the latest version by following the GitHub releases redirect
 get_latest_version() {
-    curl -s "${GITHUB_API_REPO_URL}/latest" | jq -r ".tag_name"
+    curl -sI "https://github.com/$REPO_OWNER/$REPO_NAME/releases/latest" \
+        | grep -i '^location:' | sed 's|.*/tag/||;s/\r//'
 }
 
 # Check if a version is passed as an argument

--- a/src/hurl/install.sh
+++ b/src/hurl/install.sh
@@ -5,8 +5,6 @@ REPO_OWNER="Orange-OpenSource"
 REPO_NAME="hurl"
 BINARY_NAME="hurl"
 HURL_VERSION="${VERSION:-"latest"}"
-GITHUB_API_REPO_URL="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases"
-
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
@@ -28,8 +26,8 @@ check_packages() {
     fi
 }
 
-# Make sure we have curl and jq
-check_packages curl jq ca-certificates
+# Make sure we have curl
+check_packages curl ca-certificates
 
 # Install libxml2 runtime dependency
 # On newer Ubuntu (25.04+), the package is libxml2-16 and provides libxml2.so.16
@@ -49,9 +47,10 @@ else
     fi
 fi
 
-# Function to get the latest version from GitHub API
+# Function to get the latest version by following the GitHub releases redirect
 get_latest_version() {
-    curl -s "${GITHUB_API_REPO_URL}/latest" | jq -r ".tag_name"
+    curl -sI "https://github.com/$REPO_OWNER/$REPO_NAME/releases/latest" \
+        | grep -i '^location:' | sed 's|.*/tag/||;s/\r//'
 }
 
 # Check if a version is passed as an argument

--- a/src/hyperfine/install.sh
+++ b/src/hyperfine/install.sh
@@ -5,8 +5,6 @@ REPO_OWNER="sharkdp"
 REPO_NAME="hyperfine"
 BINARY_NAME="hyperfine"
 HYPERFINE_VERSION="${VERSION:-"latest"}"
-GITHUB_API_REPO_URL="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases"
-
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
@@ -28,12 +26,13 @@ check_packages() {
     fi
 }
 
-# Make sure we have curl and jq
-check_packages curl jq ca-certificates
+# Make sure we have curl
+check_packages curl ca-certificates
 
-# Function to get the latest version from GitHub API
+# Function to get the latest version by following the GitHub releases redirect
 get_latest_version() {
-    curl -s "${GITHUB_API_REPO_URL}/latest" | jq -r ".tag_name"
+    curl -sI "https://github.com/$REPO_OWNER/$REPO_NAME/releases/latest" \
+        | grep -i '^location:' | sed 's|.*/tag/||;s/\r//'
 }
 
 # Check if a version is passed as an argument

--- a/src/jnv/install.sh
+++ b/src/jnv/install.sh
@@ -4,8 +4,6 @@
 REPO_OWNER="ynqa"
 REPO_NAME="jnv"
 JNV_VERSION="${VERSION:-"latest"}"
-GITHUB_API_REPO_URL="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases"
-
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
@@ -57,13 +55,14 @@ check_packages() {
     fi
 }
 
-# Function to get the latest version from GitHub API
+# Function to get the latest version by following the GitHub releases redirect
 get_latest_version() {
-    curl -s "${GITHUB_API_REPO_URL}/latest" | jq -r ".tag_name"
+    curl -sI "https://github.com/$REPO_OWNER/$REPO_NAME/releases/latest" \
+        | grep -i '^location:' | sed 's|.*/tag/||;s/\r//'
 }
 
 # Make sure we have required packages
-check_packages curl tar jq ca-certificates xz-utils
+check_packages curl tar ca-certificates xz-utils
 
 # Check if a version is passed as an argument
 if [ -z "$JNV_VERSION" ] || [ "$JNV_VERSION" == "latest" ]; then

--- a/src/k3d/install.sh
+++ b/src/k3d/install.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
 K3D_VERSION="${VERSION:-"latest"}"
-GITHUB_API_REPO_URL="https://api.github.com/repos/k3d-io/k3d/releases"
+REPO_OWNER="k3d-io"
+REPO_NAME="k3d"
 URL_RELEASES="https://github.com/k3d-io/k3d/releases"
 
 set -e
@@ -49,32 +50,15 @@ check_packages() {
     fi
 }
 
-# Figure out correct version of a three part version number is not passed
-validate_version_exists() {
-    local variable_name=$1
-    local requested_version=${2}
-    if [ "${requested_version}" = "latest" ]; then 
-        requested_version=$(curl -sL ${GITHUB_API_REPO_URL}/latest | jq -r ".tag_name")
-        echo "Latest version is ${requested_version}"
-    fi
-    local version_list
-    version_list=$(curl -sL ${GITHUB_API_REPO_URL} | jq -r ".[].tag_name")
-    if ! echo "${version_list}" | grep "${requested_version}" >/dev/null 2>&1; then
-        echo -e "Invalid ${variable_name} value: ${requested_version}\nValid values:\n${version_list}" >&2
-        exit 1
-    fi
-    echo "${variable_name}=${requested_version}"
-}
+# Make sure we have curl
+check_packages curl ca-certificates
 
-# Make sure we have curl and jq
-check_packages curl jq ca-certificates
-
-# Make sure version is available
-if [ "${K3D_VERSION}" = "latest" ]; then 
-    K3D_VERSION=$(curl -sL ${GITHUB_API_REPO_URL}/latest | jq -r ".tag_name")
-    echo "Latest version is ${K3D_VERSION}"
+# get latest version via redirect if not specified
+if [ "${K3D_VERSION}" = "latest" ]; then
+    K3D_VERSION=$(curl -sI "https://github.com/$REPO_OWNER/$REPO_NAME/releases/latest" \
+        | grep -i '^location:' | sed 's|.*/tag/||;s/\r//')
+    echo "No version provided or 'latest' specified, installing the latest version: $K3D_VERSION"
 fi
-validate_version_exists K3D_VERSION "${K3D_VERSION}"
 
 # Download and install binary
 K3D_DIST="k3d-${OS}-${ARCH}"

--- a/src/kyverno/install.sh
+++ b/src/kyverno/install.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 KYVERNO_VERSION="${VERSION:-"latest"}"
-GITHUB_API_REPO_URL="https://api.github.com/repos/kyverno/kyverno/releases"
+REPO_OWNER="kyverno"
+REPO_NAME="kyverno"
 URL_RELEASES="https://github.com/kyverno/kyverno/releases"
 
 set -e
@@ -45,26 +46,15 @@ check_packages() {
 	fi
 }
 
-# Figure out correct version of a three part version number is not passed
-validate_version_exists() {
-	local variable_name=$1
-    local requested_version=$2
-	if [ "${requested_version}" = "latest" ]; then requested_version=$(curl -sL ${GITHUB_API_REPO_URL}/latest | jq -r ".tag_name"); fi
-	local version_list
-    version_list=$(curl -sL ${GITHUB_API_REPO_URL} | jq -r ".[].tag_name")
-	if [ -z "${variable_name}" ] || ! echo "${version_list}" | grep "${requested_version}" >/dev/null 2>&1; then
-		echo -e "Invalid ${variable_name} value: ${requested_version}\nValid values:\n${version_list}" >&2
-		exit 1
-	fi
-	echo "${variable_name}=${requested_version}"
-}
-
 # make sure we have curl
-check_packages curl tar jq ca-certificates
+check_packages curl tar ca-certificates
 
-# make sure version is available
-if [ "${KYVERNO_VERSION}" = "latest" ]; then KYVERNO_VERSION=$(curl -sL ${GITHUB_API_REPO_URL}/latest | jq -r ".tag_name"); fi
-validate_version_exists KYVERNO_VERSION "${KYVERNO_VERSION}"
+# get latest version via redirect if not specified
+if [ "${KYVERNO_VERSION}" = "latest" ]; then
+    KYVERNO_VERSION=$(curl -sI "https://github.com/$REPO_OWNER/$REPO_NAME/releases/latest" \
+        | grep -i '^location:' | sed 's|.*/tag/||;s/\r//')
+    echo "No version provided or 'latest' specified, installing the latest version: $KYVERNO_VERSION"
+fi
 
 # download and install binary
 KYVERNO_FILENAME=kyverno-cli_${KYVERNO_VERSION}_${OS}_${ARCH}.tar.gz

--- a/src/lazygit/install.sh
+++ b/src/lazygit/install.sh
@@ -5,8 +5,6 @@ REPO_OWNER="jesseduffield"
 REPO_NAME="lazygit"
 BINARY_NAME="lazygit"
 LAZYGIT_VERSION="${VERSION:-"latest"}"
-GITHUB_API_REPO_URL="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases"
-
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
@@ -28,12 +26,13 @@ check_packages() {
     fi
 }
 
-# Make sure we have curl and jq
-check_packages curl jq ca-certificates
+# Make sure we have curl
+check_packages curl ca-certificates
 
-# Function to get the latest version from GitHub API
+# Function to get the latest version by following the GitHub releases redirect
 get_latest_version() {
-    curl -s "${GITHUB_API_REPO_URL}/latest" | jq -r ".tag_name"
+    curl -sI "https://github.com/$REPO_OWNER/$REPO_NAME/releases/latest" \
+        | grep -i '^location:' | sed 's|.*/tag/||;s/\r//'
 }
 
 # Check if a version is passed as an argument

--- a/src/notation/install.sh
+++ b/src/notation/install.sh
@@ -44,26 +44,11 @@ check_packages() {
 	fi
 }
 
-# Figure out correct version of a three part version number is not passed
-validate_version_exists() {
-	local variable_name=$1
-    local requested_version=$2
-	if [ "${requested_version}" = "latest" ]; then requested_version=$(curl -sL https://api.github.com/repos/notaryproject/notation/releases/latest | jq -r ".tag_name"); fi
-	local version_list
-    version_list=$(curl -sL https://api.github.com/repos/notaryproject/notation/releases | jq -r ".[].tag_name")
-	if [ -z "${variable_name}" ] || ! echo "${version_list}" | grep "${requested_version}" >/dev/null 2>&1; then
-		echo -e "Invalid ${variable_name} value: ${requested_version}\nValid values:\n${version_list}" >&2
-		exit 1
-	fi
-	echo "${variable_name}=${requested_version}"
-}
-
 # make sure we have curl
-check_packages curl tar jq ca-certificates
+check_packages curl tar ca-certificates
 
 # make sure version is available
-if [ "${NOTATION_VERSION}" = "latest" ]; then NOTATION_VERSION=$(curl -sL https://api.github.com/repos/notaryproject/notation/releases/latest | jq -r ".tag_name"); fi
-validate_version_exists NOTATION_VERSION "${NOTATION_VERSION}"
+if [ "${NOTATION_VERSION}" = "latest" ]; then NOTATION_VERSION=$(curl -sI "https://github.com/notaryproject/notation/releases/latest" | grep -i '^location:' | sed 's|.*/tag/||;s/\r//'); fi
 
 # download and install binary
 NOTATION_FILENAME=notation_${NOTATION_VERSION:1}_${platform}_${architecture}.tar.gz

--- a/src/opencode/install.sh
+++ b/src/opencode/install.sh
@@ -60,51 +60,18 @@ case "$OS" in
         ;;
 esac
 
-# Function to resolve the latest version using GitHub API
+# Function to resolve the latest version by following the GitHub releases redirect
 resolve_latest_version() {
-    echo "Resolving latest version using GitHub API..." >&2
-    local api_response
-    api_response=$(curl -s --max-time 10 "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases/latest" 2>/dev/null || echo "")
-
-    if [ -n "$api_response" ] && echo "$api_response" | jq -e '.tag_name' >/dev/null 2>&1; then
-        local version_tag
-        version_tag=$(echo "$api_response" | jq -r '.tag_name')
-        # Remove 'v' prefix if present
-        echo "${version_tag#v}"
-        return 0
-    else
-        echo "GitHub API failed, falling back to HTML parsing..." >&2
-        return 1
-    fi
-}
-
-# Function to resolve latest version by parsing HTML (fallback)
-resolve_latest_version_fallback() {
-    echo "Attempting to resolve latest version from releases page HTML..." >&2
-    local releases_page
-    releases_page=$(curl -s --max-time 10 "https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/latest" 2>/dev/null || echo "")
-
-    if [ -n "$releases_page" ]; then
-        # Look for version tag in the HTML
-        local version_tag
-        version_tag=$(echo "$releases_page" | grep -oE 'releases/tag/v?[0-9]+\.[0-9]+\.[0-9]+' | head -1 | sed 's/.*releases\/tag\/v\?\([0-9]\+\.[0-9]\+\.[0-9]\+\).*/\1/')
-
-        if [ -n "$version_tag" ] && [[ "$version_tag" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "$version_tag"
-            return 0
-        fi
-    fi
-
-    echo "Failed to resolve version from HTML, using known fallback version..." >&2
-    echo "1.0.223"  # Known recent version as last resort
-    return 1
+    echo "Resolving latest version..." >&2
+    local version_tag
+    version_tag=$(curl -sI "https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/latest" \
+        | grep -i '^location:' | sed 's|.*/tag/||;s/\r//')
+    echo "${version_tag#v}"
 }
 
 # Resolve version
 if [ "$OPENCODE_VERSION" = "latest" ]; then
-    if ! RESOLVED_VERSION=$(resolve_latest_version); then
-        RESOLVED_VERSION=$(resolve_latest_version_fallback) || true
-    fi
+    RESOLVED_VERSION=$(resolve_latest_version)
     echo "Resolved latest version to: $RESOLVED_VERSION"
     OPENCODE_VERSION="$RESOLVED_VERSION"
 else

--- a/src/ripgrep/install.sh
+++ b/src/ripgrep/install.sh
@@ -5,8 +5,6 @@ REPO_OWNER="BurntSushi"
 REPO_NAME="ripgrep"
 BINARY_NAME="rg"
 RIPGREP_VERSION="${VERSION:-"latest"}"
-GITHUB_API_REPO_URL="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases"
-
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
@@ -28,12 +26,13 @@ check_packages() {
     fi
 }
 
-# Make sure we have curl and jq
-check_packages curl jq ca-certificates
+# Make sure we have curl
+check_packages curl ca-certificates
 
-# Function to get the latest version from GitHub API
+# Function to get the latest version by following the GitHub releases redirect
 get_latest_version() {
-    curl -s "${GITHUB_API_REPO_URL}/latest" | jq -r ".tag_name"
+    curl -sI "https://github.com/$REPO_OWNER/$REPO_NAME/releases/latest" \
+        | grep -i '^location:' | sed 's|.*/tag/||;s/\r//'
 }
 
 # Check if a version is passed as an argument

--- a/src/rtk/install.sh
+++ b/src/rtk/install.sh
@@ -5,8 +5,6 @@ REPO_OWNER="rtk-ai"
 REPO_NAME="rtk"
 BINARY_NAME="rtk"
 RTK_VERSION="${VERSION:-"latest"}"
-GITHUB_API_REPO_URL="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases"
-
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
@@ -28,12 +26,13 @@ check_packages() {
     fi
 }
 
-# Make sure we have curl and jq
-check_packages curl jq ca-certificates
+# Make sure we have curl
+check_packages curl ca-certificates
 
-# Function to get the latest version from GitHub API
+# Function to get the latest version by following the GitHub releases redirect
 get_latest_version() {
-    curl -s "${GITHUB_API_REPO_URL}/latest" | jq -r ".tag_name"
+    curl -sI "https://github.com/$REPO_OWNER/$REPO_NAME/releases/latest" \
+        | grep -i '^location:' | sed 's|.*/tag/||;s/\r//'
 }
 
 # Check if a version is passed as an argument

--- a/src/ruff/install.sh
+++ b/src/ruff/install.sh
@@ -28,10 +28,10 @@ check_packages() {
 # make sure we have packages
 check_packages curl tar jq ca-certificates
 
-# Function to get the latest version from GitHub API
+# Function to get the latest version by following the GitHub releases redirect
 get_latest_version() {
-    LATEST_URL="https://api.github.com/repos/$REPO_OWNER/$REPO_NAME/releases/latest"
-    curl -s "$LATEST_URL" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'
+    curl -sI "https://github.com/$REPO_OWNER/$REPO_NAME/releases/latest" \
+        | grep -i '^location:' | sed 's|.*/tag/||;s/\r//'
 }
 
 # Check if a version is passed as an argument

--- a/src/tmux/install.sh
+++ b/src/tmux/install.sh
@@ -5,8 +5,6 @@ REPO_OWNER="tmux"
 REPO_NAME="tmux"
 BINARY_NAME="tmux"
 TMUX_VERSION="${VERSION:-"latest"}"
-GITHUB_API_REPO_URL="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases"
-
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
@@ -29,11 +27,12 @@ check_packages() {
 }
 
 # Make sure we have required dependencies
-check_packages curl jq ca-certificates build-essential pkg-config libevent-dev libncurses-dev bison tar
+check_packages curl ca-certificates build-essential pkg-config libevent-dev libncurses-dev bison tar
 
-# Function to get the latest version from GitHub API
+# Function to get the latest version by following the GitHub releases redirect
 get_latest_version() {
-    curl -s "${GITHUB_API_REPO_URL}/latest" | jq -r ".tag_name"
+    curl -sI "https://github.com/$REPO_OWNER/$REPO_NAME/releases/latest" \
+        | grep -i '^location:' | sed 's|.*/tag/||;s/\r//'
 }
 
 # Check if a version is passed as an argument

--- a/src/uv/install.sh
+++ b/src/uv/install.sh
@@ -28,10 +28,10 @@ check_packages() {
 # make sure we have packages
 check_packages curl tar jq ca-certificates
 
-# Function to get the latest version from GitHub API
+# Function to get the latest version by following the GitHub releases redirect
 get_latest_version() {
-    LATEST_URL="https://api.github.com/repos/$REPO_OWNER/$REPO_NAME/releases/latest"
-    curl -s "$LATEST_URL" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'
+    curl -sI "https://github.com/$REPO_OWNER/$REPO_NAME/releases/latest" \
+        | grep -i '^location:' | sed 's|.*/tag/||;s/\r//'
 }
 
 # Check if a version is passed as an argument

--- a/src/yazi/install.sh
+++ b/src/yazi/install.sh
@@ -5,8 +5,6 @@ REPO_OWNER="sxyazi"
 REPO_NAME="yazi"
 BINARY_NAME="yazi"
 YAZI_VERSION="${VERSION:-"latest"}"
-GITHUB_API_REPO_URL="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases"
-
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
@@ -28,12 +26,13 @@ check_packages() {
     fi
 }
 
-# Make sure we have curl, jq, and unzip
-check_packages curl jq ca-certificates unzip
+# Make sure we have curl and unzip
+check_packages curl ca-certificates unzip
 
-# Function to get the latest version from GitHub API
+# Function to get the latest version by following the GitHub releases redirect
 get_latest_version() {
-    curl -s "${GITHUB_API_REPO_URL}/latest" | jq -r ".tag_name"
+    curl -sI "https://github.com/$REPO_OWNER/$REPO_NAME/releases/latest" \
+        | grep -i '^location:' | sed 's|.*/tag/||;s/\r//'
 }
 
 # Check if a version is passed as an argument

--- a/src/zarf/install.sh
+++ b/src/zarf/install.sh
@@ -2,8 +2,9 @@
 
 ZARF_VERSION="${VERSION:-"latest"}"
 ZARF_DOWNLOAD_INIT="${INITFILE:-false}"
-GITHUB_API_REPO_URL="https://api.github.com/repos/defenseunicorns/zarf/releases"
-URL_RELEASES="https://github.com/defenseunicorns/zarf/releases"
+REPO_OWNER="zarf-dev"
+REPO_NAME="zarf"
+URL_RELEASES="https://github.com/zarf-dev/zarf/releases"
 
 set -e
 
@@ -48,26 +49,15 @@ check_packages() {
 	fi
 }
 
-# Figure out correct version of a three part version number is not passed
-validate_version_exists() {
-	local variable_name=$1
-    local requested_version=$2
-	if [ "${requested_version}" = "latest" ]; then requested_version=$(curl -sL ${GITHUB_API_REPO_URL}/latest | jq -r ".tag_name"); fi
-	local version_list
-    version_list=$(curl -sL ${GITHUB_API_REPO_URL} | jq -r ".[].tag_name")
-	if [ -z "${variable_name}" ] || ! echo "${version_list}" | grep "${requested_version}" >/dev/null 2>&1; then
-		echo -e "Invalid ${variable_name} value: ${requested_version}\nValid values:\n${version_list}" >&2
-		exit 1
-	fi
-	echo "${variable_name}=${requested_version}"
-}
-
 # make sure we have curl
-check_packages curl tar jq ca-certificates
+check_packages curl tar ca-certificates
 
-# make sure version is available
-if [ "${ZARF_VERSION}" = "latest" ]; then ZARF_VERSION=$(curl -sL ${GITHUB_API_REPO_URL}/latest | jq -r ".tag_name"); fi
-validate_version_exists ZARF_VERSION "${ZARF_VERSION}"
+# get latest version via redirect if not specified
+if [ "${ZARF_VERSION}" = "latest" ]; then
+    ZARF_VERSION=$(curl -sI "https://github.com/$REPO_OWNER/$REPO_NAME/releases/latest" \
+        | grep -i '^location:' | sed 's|.*/tag/||;s/\r//')
+    echo "No version provided or 'latest' specified, installing the latest version: $ZARF_VERSION"
+fi
 
 # download and install binary
 ZARF_FILENAME=zarf_${ZARF_VERSION}_${OS}_${architecture}

--- a/src/zoxide/install.sh
+++ b/src/zoxide/install.sh
@@ -5,8 +5,6 @@ REPO_OWNER="ajeetdsouza"
 REPO_NAME="zoxide"
 BINARY_NAME="zoxide"
 ZOXIDE_VERSION="${VERSION:-"latest"}"
-GITHUB_API_REPO_URL="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases"
-
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
@@ -28,12 +26,13 @@ check_packages() {
     fi
 }
 
-# Make sure we have curl and jq
-check_packages curl jq ca-certificates
+# Make sure we have curl
+check_packages curl ca-certificates
 
-# Function to get the latest version from GitHub API
+# Function to get the latest version by following the GitHub releases redirect
 get_latest_version() {
-    curl -s "${GITHUB_API_REPO_URL}/latest" | jq -r ".tag_name"
+    curl -sI "https://github.com/$REPO_OWNER/$REPO_NAME/releases/latest" \
+        | grep -i '^location:' | sed 's|.*/tag/||;s/\r//'
 }
 
 # Check if a version is passed as an argument


### PR DESCRIPTION
* Fixed github version lookups for: `bat`, `ccc`, `copa`, `crane`, `cyclonedx`, `fd`, `flux`, `fx`, `fzf`, `gic`, `gitleaks`, `glow`, `hurl`, `hyperfine`, `jnv`, `k3d`, `kyverno`, `lazygit`, `notation`, `opencode`, `ripgrep`, `rtk`, `ruff`, `tmux`, `uv`, `yazi`, `zarf`, and `zoxide`
* Fixed missing executable bit for  `ccc`, `fd`, `fx`, `fzf`, `glow`, `hurl`, `hyperfine`, `k3d`, `lazygit`, `ripgrep`, `rtk`, `tmux`, `yazi`, and `zoxide`

This replaces most GitHub API calls with a simple redirect lookup, e.g.:
```shell
$ curl -sI "https://github.com/astral-sh/uv/releases/latest" \
    | grep -i '^location:' \
    | sed 's|.*/tag/||;s/\r//'
0.11.19
```

This removes the requirement for `jq` and prevents rate-limiting from the GitHub API:

```json
{
  "message": "API rate limit exceeded for xxx.xxx.xxx.xxx. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)",
  "documentation_url": "https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting"
}
```

Codex wasn't modified as it genuinely needs the GitHub API to lookup re-release versions.

Each tool was tested with Podman for the amd64 platform as not everything here supports arm64.
* `podman run -it --rm --platform=linux/amd64 -v "$PWD:/app" debian:latest bash -c "VERSION=latest /app/src/bat/install.sh"`
* `podman run --rm --platform=linux/amd64 -v "$PWD:/app" debian:latest bash -c "/app/src/crane/install.sh"`
* `podman run --rm --platform=linux/amd64 -v "$PWD:/app" debian:latest bash -c "/app/src/cyclonedx/install.sh"`
* `podman run --rm --platform=linux/amd64 -v "$PWD:/app" debian:latest bash -c "/app/src/fd/install.sh"`
* `podman run --rm --platform=linux/amd64 -v "$PWD:/app" debian:latest bash -c "/app/src/flux/install.sh"`
* `podman run --rm --platform=linux/amd64 -v "$PWD:/app" debian:latest bash -c "/app/src/fx/install.sh"`
* `podman run --rm --platform=linux/amd64 -v "$PWD:/app" debian:latest bash -c "/app/src/fzf/install.sh"`
* `podman run --rm --platform=linux/amd64 -v "$PWD:/app" debian:latest bash -c "/app/src/gic/install.sh"`
* `podman run --rm --platform=linux/amd64 -v "$PWD:/app" debian:latest bash -c "/app/src/gitleaks/install.sh"`
* `podman run --rm --platform=linux/amd64 -v "$PWD:/app" debian:latest bash -c "/app/src/glow/install.sh"`
* `podman run --rm --platform=linux/amd64 -v "$PWD:/app" debian:latest bash -c "/app/src/hurl/install.sh"`
* `podman run --rm --platform=linux/amd64 -v "$PWD:/app" debian:latest bash -c "/app/src/hyperfine/install.sh"`
* `podman run --rm --platform=linux/amd64 -v "$PWD:/app" debian:latest bash -c "/app/src/jnv/install.sh"`
* `podman run --rm --platform=linux/amd64 -v "$PWD:/app" debian:latest bash -c "/app/src/k3d/install.sh"`
* `podman run --rm --platform=linux/amd64 -v "$PWD:/app" debian:latest bash -c "/app/src/kyverno/install.sh"`
* `podman run --rm --platform=linux/amd64 -v "$PWD:/app" debian:latest bash -c "/app/src/lazygit/install.sh"`
* `podman run --rm --platform=linux/amd64 -v "$PWD:/app" debian:latest bash -c "/app/src/notation/install.sh"`
* `podman run --rm --platform=linux/amd64 -v "$PWD:/app" debian:latest bash -c "/app/src/opencode/install.sh"`
* `podman run --rm --platform=linux/amd64 -v "$PWD:/app" debian:latest bash -c "/app/src/ripgrep/install.sh"`
* `podman run --rm --platform=linux/amd64 -v "$PWD:/app" debian:latest bash -c "/app/src/rtk/install.sh"`
* `podman run --rm --platform=linux/amd64 -v "$PWD:/app" debian:latest bash -c "/app/src/ruff/install.sh"`
* `podman run --rm --platform=linux/amd64 -v "$PWD:/app" debian:latest bash -c "/app/src/tmux/install.sh"`
* `podman run --rm --platform=linux/amd64 -v "$PWD:/app" debian:latest bash -c "/app/src/uv/install.sh"`
* `podman run --rm --platform=linux/amd64 -v "$PWD:/app" debian:latest bash -c "/app/src/yazi/install.sh"`
* `podman run --rm --platform=linux/amd64 -v "$PWD:/app" debian:latest bash -c "/app/src/zarf/install.sh"`
* `podman run --rm --platform=linux/amd64 -v "$PWD:/app" debian:latest bash -c "/app/src/zoxide/install.sh"`