### PR TITLE
feat: add ast-grep dev container feature

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,6 +43,7 @@ jobs:
           - fx
           - hurl
           - markitdown
+          - ast-grep
         baseImage:
           - debian:latest
           - ubuntu:latest

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ This repository contains a _collection_ of Features.
 | fx | https://github.com/antonmedv/fx | Terminal JSON viewer & processor. |
 | hurl | https://github.com/Orange-OpenSource/hurl | Run and test HTTP requests with plain text. |
 | MarkItDown | https://github.com/microsoft/markitdown | Convert PDFs, Office docs, images, audio, HTML, CSV/JSON/XML, ZIPs, and more into Markdown from the CLI. |
+| ast-grep | https://github.com/ast-grep/ast-grep | Structural code search, linting, and rewriting using AST-aware patterns. |
 
 
 
@@ -468,16 +469,21 @@ hurl --version
 ### `markitdown`
 
 Running `markitdown --version` inside the built container will print the version of markitdown.
+### `ast-grep`
+
+Running `sg --version` inside the built container will print the version of ast-grep.
 
 ```jsonc
 {
     "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
     "features": {
         "ghcr.io/jsburckhardt/devcontainer-features/markitdown:1": {}
+        "ghcr.io/jsburckhardt/devcontainer-features/ast-grep:1": {}
     }
 }
 ```
 
 ```bash
 markitdown --version
+sg --version
 ```

--- a/src/ast-grep/devcontainer-feature.json
+++ b/src/ast-grep/devcontainer-feature.json
@@ -1,0 +1,13 @@
+{
+    "name": "ast-grep",
+    "id": "ast-grep",
+    "version": "1.0.0",
+    "description": "Structural code search, linting, and rewriting using AST-aware patterns.",
+    "options": {
+        "version": {
+            "type": "string",
+            "default": "latest",
+            "description": "Version to install from GitHub releases"
+        }
+    }
+}

--- a/src/ast-grep/install.sh
+++ b/src/ast-grep/install.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+
+# Variables
+REPO_OWNER="ast-grep"
+REPO_NAME="ast-grep"
+BINARY_NAME="sg"
+AST_GREP_VERSION="${VERSION:-"latest"}"
+GITHUB_API_REPO_URL="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases"
+
+set -e
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+# Checks if packages are installed and installs them if not
+check_packages() {
+    if ! dpkg -s "$@" >/dev/null 2>&1; then
+        if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+            echo "Running apt-get update..."
+            apt-get update -y
+        fi
+        apt-get -y install --no-install-recommends "$@"
+    fi
+}
+
+# Make sure we have curl, jq, and unzip
+check_packages curl jq ca-certificates unzip
+
+# Function to get the latest version from GitHub API
+get_latest_version() {
+    local version
+    version=$(curl -fsSL "${GITHUB_API_REPO_URL}/latest" | jq -r ".tag_name")
+    if [ -z "$version" ] || [ "$version" = "null" ]; then
+        echo "Failed to resolve latest ast-grep version from GitHub API (possibly rate-limited)." >&2
+        return 1
+    fi
+    echo "$version"
+}
+
+# Check if a version is passed as an argument
+if [ -z "$AST_GREP_VERSION" ] || [ "$AST_GREP_VERSION" == "latest" ]; then
+    # No version provided, get the latest version
+    AST_GREP_VERSION=$(get_latest_version)
+    echo "No version provided or 'latest' specified, installing the latest version: $AST_GREP_VERSION"
+else
+    echo "Installing version from environment variable: $AST_GREP_VERSION"
+fi
+
+# Determine the OS and architecture
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+
+case "$ARCH" in
+    x86_64)
+        ARCH="x86_64"
+        ;;
+    i686)
+        ARCH="i686"
+        ;;
+    aarch64)
+        ARCH="aarch64"
+        ;;
+    armv7l)
+        ARCH="armv7"
+        ;;
+    *)
+        echo "Unsupported architecture: $ARCH"
+        exit 1
+        ;;
+esac
+
+case "$OS" in
+    linux)
+        OS="unknown-linux-gnu"
+        ;;
+    darwin)
+        OS="apple-darwin"
+        ;;
+    *)
+        echo "Unsupported OS: $OS"
+        exit 1
+        ;;
+esac
+
+# Construct the download URL
+DOWNLOAD_URL="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/${AST_GREP_VERSION}/app-${ARCH}-${OS}.zip"
+
+# Create a temporary directory for the download
+TMP_DIR=$(mktemp -d)
+cd "$TMP_DIR" || exit
+
+echo "Downloading ast-grep from $DOWNLOAD_URL"
+curl -fsSL "$DOWNLOAD_URL" -o "ast-grep.zip"
+
+# Extract the zip
+echo "Extracting ast-grep..."
+unzip -o "ast-grep.zip"
+
+# Move the binaries to /usr/local/bin
+echo "Installing ast-grep..."
+mv sg /usr/local/bin/
+mv ast-grep /usr/local/bin/
+
+# Cleanup
+cd - || exit
+rm -rf "$TMP_DIR"
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+# Verify installation
+echo "Verifying installation..."
+sg --version
+
+echo "Done!"

--- a/test/_global/all-tools.sh
+++ b/test/_global/all-tools.sh
@@ -32,5 +32,6 @@ check "glow" glow --version
 check "fx" fx --version
 check "hurl" hurl --version
 check "markitdown" markitdown --version
+check "ast-grep" sg --version
 
 reportResults

--- a/test/_global/ast-grep-specific-version.sh
+++ b/test/_global/ast-grep-specific-version.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+source dev-container-features-test-lib
+check "ast-grep with specific version" /bin/bash -c "sg --version | grep '0.36.0'"
+reportResults

--- a/test/_global/scenarios.json
+++ b/test/_global/scenarios.json
@@ -34,6 +34,7 @@
             "glow": {},
             "fx": {},
             "markitdown": {}
+            "ast-grep": {}
         }
     },
     "flux-specific-version": {
@@ -271,6 +272,11 @@
         "features": {
             "markitdown": {
                 "version": "0.1.6"
+    "ast-grep-specific-version": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "ast-grep": {
+                "version": "0.36.0"
             }
         }
     }

--- a/test/_global/scenarios.json
+++ b/test/_global/scenarios.json
@@ -33,7 +33,7 @@
             "hyperfine": {},
             "glow": {},
             "fx": {},
-            "markitdown": {}
+            "markitdown": {},
             "ast-grep": {}
         }
     },
@@ -272,6 +272,9 @@
         "features": {
             "markitdown": {
                 "version": "0.1.6"
+            }
+        }
+    },
     "ast-grep-specific-version": {
         "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
         "features": {

--- a/test/ast-grep/test.sh
+++ b/test/ast-grep/test.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+source dev-container-features-test-lib
+check "ast-grep" sg --version
+reportResults


### PR DESCRIPTION
Structural code search, linting, and rewriting using AST-aware patterns. Source: ast-grep/ast-grep.

Verified locally with `devcontainer features test -f ast-grep -i ubuntu:latest .` ✅

Scaffolded with the @new-feature agent in a parallel-worktree workflow.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>