### PR TITLE
feat: add mise dev container feature

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,6 +44,7 @@ jobs:
           - hurl
           - markitdown
           - ast-grep
+          - mise
         baseImage:
           - debian:latest
           - ubuntu:latest

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ This repository contains a _collection_ of Features.
 | hurl | https://github.com/Orange-OpenSource/hurl | Run and test HTTP requests with plain text. |
 | MarkItDown | https://github.com/microsoft/markitdown | Convert PDFs, Office docs, images, audio, HTML, CSV/JSON/XML, ZIPs, and more into Markdown from the CLI. |
 | ast-grep | https://github.com/ast-grep/ast-grep | Structural code search, linting, and rewriting using AST-aware patterns. |
+| mise | https://github.com/jdx/mise | Manage dev tool versions, environment variables, and project tasks in one CLI. |
 
 
 
@@ -434,6 +435,22 @@ Running `fx --version` inside the built container will print the version of fx.
 ### `hurl`
 
 Running `hurl --version` inside the built container will print the version of hurl.
+### `mise`
+
+Running `mise --version` inside the built container will print the version of mise.
+
+```jsonc
+{
+    "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+    "features": {
+        "ghcr.io/jsburckhardt/devcontainer-features/mise:1": {}
+    }
+}
+```
+
+```bash
+mise --version
+```
 
 ```jsonc
 {

--- a/src/mise/devcontainer-feature.json
+++ b/src/mise/devcontainer-feature.json
@@ -1,0 +1,13 @@
+{
+    "name": "mise",
+    "id": "mise",
+    "version": "1.0.0",
+    "description": "Manage dev tool versions, environment variables, and project tasks in one CLI.",
+    "options": {
+        "version": {
+            "type": "string",
+            "default": "latest",
+            "description": "Version to install from GitHub releases (e.g., v2024.7.1)"
+        }
+    }
+}

--- a/src/mise/install.sh
+++ b/src/mise/install.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+
+# Variables
+REPO_OWNER="jdx"
+REPO_NAME="mise"
+BINARY_NAME="mise"
+MISE_VERSION="${VERSION:-"latest"}"
+GITHUB_API_REPO_URL="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases"
+
+set -e
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+# Checks if packages are installed and installs them if not
+check_packages() {
+    if ! dpkg -s "$@" >/dev/null 2>&1; then
+        if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+            echo "Running apt-get update..."
+            apt-get update -y
+        fi
+        apt-get -y install --no-install-recommends "$@"
+    fi
+}
+
+# Make sure we have curl and jq
+check_packages curl jq ca-certificates
+
+# Function to get the latest version from GitHub API
+get_latest_version() {
+    local version
+    version=$(curl -fsSL "${GITHUB_API_REPO_URL}/latest" | jq -r ".tag_name")
+    if [ -z "$version" ] || [ "$version" = "null" ]; then
+        echo "Failed to resolve latest mise version from GitHub API (possibly rate-limited)." >&2
+        return 1
+    fi
+    echo "$version"
+}
+
+# Check if a version is passed as an argument
+if [ -z "$MISE_VERSION" ] || [ "$MISE_VERSION" == "latest" ]; then
+    # No version provided, get the latest version
+    MISE_VERSION=$(get_latest_version)
+    echo "No version provided or 'latest' specified, installing the latest version: $MISE_VERSION"
+else
+    echo "Installing version from environment variable: $MISE_VERSION"
+fi
+
+# Determine the OS and architecture
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+
+case "$ARCH" in
+    x86_64)
+        ARCH="x64"
+        ;;
+    aarch64)
+        ARCH="arm64"
+        ;;
+    armv7l)
+        ARCH="armv7"
+        ;;
+    *)
+        echo "Unsupported architecture: $ARCH"
+        exit 1
+        ;;
+esac
+
+case "$OS" in
+    linux)
+        OS="linux"
+        ;;
+    darwin)
+        OS="macos"
+        ;;
+    *)
+        echo "Unsupported OS: $OS"
+        exit 1
+        ;;
+esac
+
+# Construct the download URL (mise provides standalone binaries)
+DOWNLOAD_URL="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/${MISE_VERSION}/mise-${MISE_VERSION}-${OS}-${ARCH}"
+
+echo "Downloading mise from $DOWNLOAD_URL"
+curl -fsSL "$DOWNLOAD_URL" -o /usr/local/bin/mise
+
+# Make binary executable
+chmod +x /usr/local/bin/mise
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+# Verify installation
+echo "Verifying installation..."
+mise --version
+
+echo "Done!"

--- a/test/_global/all-tools.sh
+++ b/test/_global/all-tools.sh
@@ -33,5 +33,6 @@ check "fx" fx --version
 check "hurl" hurl --version
 check "markitdown" markitdown --version
 check "ast-grep" sg --version
+check "mise" mise --version
 
 reportResults

--- a/test/_global/mise-specific-version.sh
+++ b/test/_global/mise-specific-version.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+source dev-container-features-test-lib
+check "mise with specific version" /bin/bash -c "mise --version | grep '2024.7.1'"
+reportResults

--- a/test/_global/scenarios.json
+++ b/test/_global/scenarios.json
@@ -34,7 +34,7 @@
             "glow": {},
             "fx": {},
             "markitdown": {},
-            "ast-grep": {}
+            "ast-grep": {},
             "mise": {}
         }
     },
@@ -281,6 +281,9 @@
         "features": {
             "ast-grep": {
                 "version": "0.36.0"
+            }
+        }
+    },
     "mise-specific-version": {
         "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
         "features": {

--- a/test/_global/scenarios.json
+++ b/test/_global/scenarios.json
@@ -35,6 +35,7 @@
             "fx": {},
             "markitdown": {},
             "ast-grep": {}
+            "mise": {}
         }
     },
     "flux-specific-version": {
@@ -280,6 +281,11 @@
         "features": {
             "ast-grep": {
                 "version": "0.36.0"
+    "mise-specific-version": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "mise": {
+                "version": "v2024.7.1"
             }
         }
     }

--- a/test/mise/test.sh
+++ b/test/mise/test.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+source dev-container-features-test-lib
+check "mise" mise --version
+reportResults


### PR DESCRIPTION
Manage dev tool versions, environment variables, and project tasks in one CLI. Source: jdx/mise.

Verified locally with `devcontainer features test -f mise -i ubuntu:latest .` ✅

Scaffolded with the @new-feature agent in a parallel-worktree workflow.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>