### PR TITLE
feat: add difftastic dev container feature

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,6 +46,7 @@ jobs:
           - ast-grep
           - mise
           - jj
+          - difftastic
         baseImage:
           - debian:latest
           - ubuntu:latest

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ This repository contains a _collection_ of Features.
 | ast-grep | https://github.com/ast-grep/ast-grep | Structural code search, linting, and rewriting using AST-aware patterns. |
 | mise | https://github.com/jdx/mise | Manage dev tool versions, environment variables, and project tasks in one CLI. |
 | jj | https://github.com/jj-vcs/jj | Git-compatible version control with a cleaner workflow for commits, branches, rebasing, and history editing. |
+| difftastic | https://github.com/Wilfred/difftastic | Syntax-aware structural diffs that are much easier to read than plain text diffs. |
 
 
 
@@ -439,12 +440,16 @@ Running `hurl --version` inside the built container will print the version of hu
 ### `mise`
 
 Running `mise --version` inside the built container will print the version of mise.
+### `difftastic`
+
+Running `difft --version` inside the built container will print the version of difftastic.
 
 ```jsonc
 {
     "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
     "features": {
         "ghcr.io/jsburckhardt/devcontainer-features/mise:1": {}
+        "ghcr.io/jsburckhardt/devcontainer-features/difftastic:1": {}
     }
 }
 ```
@@ -468,6 +473,7 @@ Running `jj --version` inside the built container will print the version of jj.
 
 ```bash
 jj --version
+difft --version
 ```
 
 ```jsonc

--- a/src/difftastic/devcontainer-feature.json
+++ b/src/difftastic/devcontainer-feature.json
@@ -1,0 +1,13 @@
+{
+    "name": "Difftastic",
+    "id": "difftastic",
+    "version": "1.0.0",
+    "description": "Syntax-aware structural diffs that are much easier to read than plain text diffs.",
+    "options": {
+        "version": {
+            "type": "string",
+            "default": "latest",
+            "description": "Version to install from GitHub releases"
+        }
+    }
+}

--- a/src/difftastic/install.sh
+++ b/src/difftastic/install.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+
+# Variables
+REPO_OWNER="Wilfred"
+REPO_NAME="difftastic"
+BINARY_NAME="difft"
+DIFFTASTIC_VERSION="${VERSION:-"latest"}"
+GITHUB_API_REPO_URL="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases"
+
+set -e
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+# Checks if packages are installed and installs them if not
+check_packages() {
+    if ! dpkg -s "$@" >/dev/null 2>&1; then
+        if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+            echo "Running apt-get update..."
+            apt-get update -y
+        fi
+        apt-get -y install --no-install-recommends "$@"
+    fi
+}
+
+# Make sure we have curl and jq
+check_packages curl jq ca-certificates
+
+# Function to get the latest version from GitHub API
+get_latest_version() {
+    curl -s "${GITHUB_API_REPO_URL}/latest" | jq -r ".tag_name"
+}
+
+# Check if a version is passed as an argument
+if [ -z "$DIFFTASTIC_VERSION" ] || [ "$DIFFTASTIC_VERSION" == "latest" ]; then
+    # No version provided, get the latest version
+    DIFFTASTIC_VERSION=$(get_latest_version)
+    echo "No version provided or 'latest' specified, installing the latest version: $DIFFTASTIC_VERSION"
+else
+    echo "Installing version from environment variable: $DIFFTASTIC_VERSION"
+fi
+
+# Determine the OS and architecture
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+
+case "$ARCH" in
+    x86_64)
+        ARCH="x86_64"
+        ;;
+    aarch64)
+        ARCH="aarch64"
+        ;;
+    *)
+        echo "Unsupported architecture: $ARCH"
+        exit 1
+        ;;
+esac
+
+case "$OS" in
+    linux)
+        OS="unknown-linux-gnu"
+        ;;
+    darwin)
+        OS="apple-darwin"
+        ;;
+    *)
+        echo "Unsupported OS: $OS"
+        exit 1
+        ;;
+esac
+
+# Construct the download URL
+DOWNLOAD_URL="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/${DIFFTASTIC_VERSION}/difft-${ARCH}-${OS}.tar.gz"
+
+# Create a temporary directory for the download
+TMP_DIR=$(mktemp -d)
+cd "$TMP_DIR" || exit
+
+echo "Downloading difftastic from $DOWNLOAD_URL"
+curl -sSL "$DOWNLOAD_URL" -o "difft.tar.gz"
+
+# Extract the tarball
+echo "Extracting difftastic..."
+tar -xzf "difft.tar.gz"
+
+# Move the binary to /usr/local/bin
+echo "Installing difftastic..."
+mv "${BINARY_NAME}" /usr/local/bin/
+
+# Cleanup
+cd - || exit
+rm -rf "$TMP_DIR"
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+# Verify installation
+echo "Verifying installation..."
+difft --version
+
+echo "Done!"

--- a/test/_global/all-tools.sh
+++ b/test/_global/all-tools.sh
@@ -35,5 +35,6 @@ check "markitdown" markitdown --version
 check "ast-grep" sg --version
 check "mise" mise --version
 check "jj" jj --version
+check "difftastic" difft --version
 
 reportResults

--- a/test/_global/difftastic-specific-version.sh
+++ b/test/_global/difftastic-specific-version.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+source dev-container-features-test-lib
+check "difftastic with specific version" /bin/bash -c "difft --version | grep '0.63.0'"
+reportResults

--- a/test/_global/scenarios.json
+++ b/test/_global/scenarios.json
@@ -36,7 +36,8 @@
             "markitdown": {},
             "ast-grep": {},
             "mise": {},
-            "jj": {}
+            "jj": {},
+            "difftastic": {}
         }
     },
     "flux-specific-version": {
@@ -298,6 +299,14 @@
         "features": {
             "jj": {
                 "version": "v0.42.0"
+            }
+        }
+    },
+    "difftastic-specific-version": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "difftastic": {
+                "version": "0.63.0"
             }
         }
     }

--- a/test/difftastic/test.sh
+++ b/test/difftastic/test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+source dev-container-features-test-lib
+check "difftastic" difft --version
+reportResults


### PR DESCRIPTION
Syntax-aware structural diffs that are much easier to read than plain text diffs. Source: Wilfred/difftastic. Binary name: `difft`.

Verified locally with `devcontainer features test -f difftastic -i ubuntu:latest .` ✅

Scaffolded with the @new-feature agent in a parallel-worktree workflow.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>