### PR TITLE
feat: add skillspector dev container feature

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -51,6 +51,7 @@ jobs:
           - actionlint
           - zizmor
           - open-code-review
+          - skillspector
         baseImage:
           - debian:latest
           - ubuntu:latest

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ This repository contains a _collection_ of Features.
 | actionlint | https://github.com/rhysd/actionlint | Static checker for GitHub Actions workflow files. |
 | zizmor | https://github.com/zizmorcore/zizmor | Static security analysis for GitHub Actions workflows. |
 | open-code-review | https://github.com/alibaba/open-code-review | CLI-oriented code review tool for diffs with deterministic checks plus optional LLM review. |
+| SkillSpector | https://github.com/NVIDIA/SkillSpector | Standalone security scanner for local AI-agent skill/config files; useful only if you want an AI-dev-security feature. |
 
 
 
@@ -517,6 +518,19 @@ delta --version
 }
 ```
 
+### `skillspector`
+
+Running `skillspector --version` inside the built container will print the version of skillspector.
+
+```jsonc
+{
+    "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+    "features": {
+        "ghcr.io/jsburckhardt/devcontainer-features/skillspector:1": {}
+    }
+}
+```
+
 ```bash
 fzf --version
 lazygit --version
@@ -548,6 +562,7 @@ Running `actionlint` inside the built container will check GitHub Actions workfl
 
 ```bash
 actionlint --version
+skillspector --version
 ```
 
 ### `markitdown`

--- a/src/skillspector/devcontainer-feature.json
+++ b/src/skillspector/devcontainer-feature.json
@@ -1,0 +1,13 @@
+{
+    "name": "SkillSpector",
+    "id": "skillspector",
+    "version": "1.0.0",
+    "description": "Standalone security scanner for local AI-agent skill/config files; useful only if you want an AI-dev-security feature.",
+    "options": {
+        "version": {
+            "type": "string",
+            "default": "latest",
+            "description": "Version of skillspector to install from GitHub releases e.g. v1.0.0"
+        }
+    }
+}

--- a/src/skillspector/install.sh
+++ b/src/skillspector/install.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+# Variables
+REPO_OWNER="NVIDIA"
+REPO_NAME="SkillSpector"
+BINARY_NAME="skillspector"
+SKILLSPECTOR_VERSION="${VERSION:-"latest"}"
+# SkillSpector upstream pyproject pins Python >=3.12,<3.14. We provision it via uv.
+PYTHON_VERSION="${PYTHON_VERSION:-3.13}"
+GITHUB_API_REPO_URL="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}"
+
+set -e
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+# Checks if packages are installed and installs them if not
+check_packages() {
+    if ! dpkg -s "$@" >/dev/null 2>&1; then
+        if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+            echo "Running apt-get update..."
+            apt-get update -y
+        fi
+        apt-get -y install --no-install-recommends "$@"
+    fi
+}
+
+check_packages curl jq ca-certificates tar git
+
+# Map architecture for uv asset naming
+ARCH=$(uname -m)
+case "$ARCH" in
+    x86_64) UV_ARCH="x86_64" ;;
+    aarch64) UV_ARCH="aarch64" ;;
+    armv7l) UV_ARCH="armv7" ;;
+    *) echo "Unsupported architecture: $ARCH"; exit 1 ;;
+esac
+
+# Bootstrap uv from astral-sh/uv GitHub releases. uv handles Python toolchain
+# provisioning so we can satisfy SkillSpector's strict <3.14 Python requirement
+# regardless of the base image's system Python.
+if ! command -v uv >/dev/null 2>&1; then
+    UV_LATEST=$(curl -s https://api.github.com/repos/astral-sh/uv/releases/latest | jq -r '.tag_name')
+    UV_URL="https://github.com/astral-sh/uv/releases/download/${UV_LATEST}/uv-${UV_ARCH}-unknown-linux-gnu.tar.gz"
+    UV_TMP=$(mktemp -d)
+    echo "Installing uv ${UV_LATEST} from ${UV_URL}"
+    curl -sSL "${UV_URL}" -o "${UV_TMP}/uv.tar.gz"
+    tar -xzf "${UV_TMP}/uv.tar.gz" -C "${UV_TMP}"
+    mv "${UV_TMP}/uv-${UV_ARCH}-unknown-linux-gnu/uv" /usr/local/bin/uv
+    mv "${UV_TMP}/uv-${UV_ARCH}-unknown-linux-gnu/uvx" /usr/local/bin/uvx
+    chmod +x /usr/local/bin/uv /usr/local/bin/uvx
+    rm -rf "${UV_TMP}"
+fi
+
+# Resolve git ref. SkillSpector has no GitHub releases; we pin against a Git ref
+# (tag, branch, or commit SHA). "latest" resolves to the default branch's HEAD SHA.
+get_default_branch_sha() {
+    local branch
+    branch=$(curl -s "${GITHUB_API_REPO_URL}" | jq -r '.default_branch')
+    curl -s "${GITHUB_API_REPO_URL}/commits/${branch}" | jq -r '.sha'
+}
+
+if [ -z "$SKILLSPECTOR_VERSION" ] || [ "$SKILLSPECTOR_VERSION" == "latest" ]; then
+    SKILLSPECTOR_VERSION=$(get_default_branch_sha)
+    echo "No version provided or 'latest' specified, installing from default branch HEAD: $SKILLSPECTOR_VERSION"
+else
+    echo "Installing SkillSpector at git ref: $SKILLSPECTOR_VERSION"
+fi
+
+# Use uv to install into a system-wide tool location with the right Python
+export UV_TOOL_DIR="${UV_TOOL_DIR:-/opt/uv-tools}"
+export UV_TOOL_BIN_DIR="${UV_TOOL_BIN_DIR:-/usr/local/bin}"
+export UV_PYTHON_INSTALL_DIR="${UV_PYTHON_INSTALL_DIR:-/opt/uv-python}"
+mkdir -p "${UV_TOOL_DIR}" "${UV_PYTHON_INSTALL_DIR}"
+
+PIP_SPEC="git+https://github.com/${REPO_OWNER}/${REPO_NAME}.git@${SKILLSPECTOR_VERSION}"
+
+echo "Installing skillspector from ${PIP_SPEC} via uv tool (python=${PYTHON_VERSION})..."
+uv tool install --python "${PYTHON_VERSION}" "${PIP_SPEC}"
+
+# Cleanup
+rm -rf /var/lib/apt/lists/*
+
+# Verify installation
+echo "Verifying installation..."
+skillspector --version
+
+echo "Done!"

--- a/test/_global/all-tools.sh
+++ b/test/_global/all-tools.sh
@@ -40,5 +40,6 @@ check "delta" delta --version
 check "actionlint" actionlint --version
 check "zizmor" zizmor --version
 check "open-code-review" opencodereview --version
+check "skillspector" skillspector --version
 
 reportResults

--- a/test/_global/scenarios.json
+++ b/test/_global/scenarios.json
@@ -41,7 +41,8 @@
             "delta": {},
             "actionlint": {},
             "zizmor": {},
-            "open-code-review": {}
+            "open-code-review": {},
+            "skillspector": {}
         }
     },
     "flux-specific-version": {
@@ -343,6 +344,14 @@
         "features": {
             "open-code-review": {
                 "version": "v1.4.1"
+            }
+        }
+    },
+    "skillspector-specific-version": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "skillspector": {
+                "version": "8f37cfa1ebc2"
             }
         }
     }

--- a/test/_global/skillspector-specific-version.sh
+++ b/test/_global/skillspector-specific-version.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+source dev-container-features-test-lib
+check "skillspector with specific version" /bin/bash -c "skillspector --version | grep '2.3.5'"
+
+reportResults

--- a/test/skillspector/test.sh
+++ b/test/skillspector/test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+source dev-container-features-test-lib
+check "skillspector" skillspector --version
+reportResults


### PR DESCRIPTION
Standalone security scanner for local AI-agent skill/config files. Source: NVIDIA/SkillSpector. No upstream binary releases; bootstraps `uv` from astral-sh/uv GitHub releases, then installs SkillSpector from Git source pinned to a commit SHA, with Python 3.13 provisioned by uv.

Verified locally with `devcontainer features test -f skillspector -i ubuntu:latest .` ✅

Scaffolded with the @new-feature agent in a parallel-worktree workflow.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>