### PR TITLE
feat: add officecli dev container feature

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -53,6 +53,7 @@ jobs:
           - open-code-review
           - skillspector
           - herdr
+          - officecli
         baseImage:
           - debian:latest
           - ubuntu:latest

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ This repository contains a _collection_ of Features.
 | open-code-review | https://github.com/alibaba/open-code-review | CLI-oriented code review tool for diffs with deterministic checks plus optional LLM review. |
 | SkillSpector | https://github.com/NVIDIA/SkillSpector | Standalone security scanner for local AI-agent skill/config files; useful only if you want an AI-dev-security feature. |
 | herdr | https://github.com/ogulcancelik/herdr | Fast, cross-platform CLI tool distributed as a static binary via GitHub releases. |
+| officecli | https://github.com/iOfficeAI/OfficeCLI | AI-friendly CLI to read, edit, and automate Word, Excel, and PowerPoint files — single static binary, no Office install required. |
 
 
 
@@ -769,4 +770,21 @@ Running `herdr --version` inside the built container will print the version of h
 
 ```bash
 herdr --version
+```
+
+### `officecli`
+
+Running `officecli --version` inside the built container will print the version of officecli.
+
+```jsonc
+{
+    "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+    "features": {
+        "ghcr.io/jsburckhardt/devcontainer-features/officecli:1": {}
+    }
+}
+```
+
+```bash
+officecli --version
 ```

--- a/src/officecli/devcontainer-feature.json
+++ b/src/officecli/devcontainer-feature.json
@@ -1,0 +1,13 @@
+{
+    "name": "officecli",
+    "id": "officecli",
+    "version": "1.0.0",
+    "description": "AI-friendly CLI to read, edit, and automate Microsoft Office files (.docx, .xlsx, .pptx) as a single static binary — no Office installation required.",
+    "options": {
+        "version": {
+            "type": "string",
+            "default": "latest",
+            "description": "Version of officecli to install from GitHub releases (e.g. 'latest' or 'v1.0.139')."
+        }
+    }
+}

--- a/src/officecli/install.sh
+++ b/src/officecli/install.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+
+# Variables
+REPO_OWNER="iOfficeAI"
+REPO_NAME="OfficeCLI"
+BINARY_NAME="officecli"
+
+set -e
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+check_packages() {
+    if ! dpkg -s "$@" >/dev/null 2>&1; then
+        if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+            echo "Running apt-get update..."
+            apt-get update -y
+        fi
+        apt-get -y install --no-install-recommends "$@"
+    fi
+}
+
+# make sure we have packages
+# libicu-dev pulls in the libicuXX runtime that the .NET AOT binary needs
+check_packages curl jq ca-certificates libicu-dev
+
+# Function to get the latest version from GitHub API
+get_latest_version() {
+    LATEST_URL="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases/latest"
+    VERSION_TAG=$(curl -sL "${LATEST_URL}" | jq -r '.tag_name // ""')
+    if [ -z "${VERSION_TAG}" ] || [ "${VERSION_TAG}" = "null" ]; then
+        # Fallback: pick the most recent release (may include pre-releases)
+        VERSION_TAG=$(curl -sL "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases" | jq -r '.[0].tag_name // ""')
+    fi
+    if [ -z "${VERSION_TAG}" ] || [ "${VERSION_TAG}" = "null" ]; then
+        echo "Error: Could not determine latest ${BINARY_NAME} version from GitHub API." >&2
+        exit 1
+    fi
+    echo "${VERSION_TAG}"
+}
+
+# Resolve version
+VERSION="${VERSION:-latest}"
+if [ -z "${VERSION}" ] || [ "${VERSION}" = "latest" ]; then
+    VERSION=$(get_latest_version)
+    echo "No version provided or 'latest' specified, installing the latest version: ${VERSION}"
+else
+    echo "Installing officecli version: ${VERSION}"
+fi
+
+# Determine OS
+OS_RAW="$(uname -s)"
+case "${OS_RAW}" in
+    Linux)  OS="linux"  ;;
+    Darwin) OS="mac"    ;;
+    *)
+        echo "(!) Platform ${OS_RAW} unsupported"
+        exit 1
+        ;;
+esac
+
+# Determine architecture — officecli release assets use x64/arm64 naming
+ARCH_RAW="$(uname -m)"
+case "${ARCH_RAW}" in
+    x86_64 | amd64)    ARCH="x64"   ;;
+    aarch64 | arm64)   ARCH="arm64" ;;
+    *)
+        echo "(!) Architecture ${ARCH_RAW} unsupported by officecli releases"
+        exit 1
+        ;;
+esac
+
+ASSET_NAME="${BINARY_NAME}-${OS}-${ARCH}"
+DOWNLOAD_URL="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/${VERSION}/${ASSET_NAME}"
+
+# Create a temporary directory for the download
+TMP_DIR="$(mktemp -d)"
+cd "${TMP_DIR}"
+
+echo "Downloading ${BINARY_NAME} from ${DOWNLOAD_URL}"
+curl -fsSL -o "${BINARY_NAME}" "${DOWNLOAD_URL}"
+
+chmod +x "${BINARY_NAME}"
+mv "${BINARY_NAME}" "/usr/local/bin/${BINARY_NAME}"
+
+# Cleanup
+cd /
+rm -rf "${TMP_DIR}"
+rm -rf /var/lib/apt/lists/*
+
+# Verify installation
+echo "Verifying installation"
+"${BINARY_NAME}" --version
+
+echo "Done!"

--- a/test/_global/all-tools.sh
+++ b/test/_global/all-tools.sh
@@ -42,5 +42,6 @@ check "zizmor" zizmor --version
 check "open-code-review" opencodereview --version
 check "skillspector" skillspector --version
 check "herdr" herdr --version
+check "officecli" officecli --version
 
 reportResults

--- a/test/_global/kyverno-specific-version.sh
+++ b/test/_global/kyverno-specific-version.sh
@@ -2,6 +2,6 @@
 
 set -e
 source dev-container-features-test-lib
-check "kyverno with specific version" /bin/bash -c "kyverno version | grep '1.15.2'"
+check "kyverno with specific version" /bin/bash -c "kyverno version | grep '1.18.2'"
 
 reportResults

--- a/test/_global/officecli-specific-version.sh
+++ b/test/_global/officecli-specific-version.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+source dev-container-features-test-lib
+check "officecli with specific version" /bin/bash -c "officecli --version | grep '1.0.139'"
+reportResults

--- a/test/_global/scenarios.json
+++ b/test/_global/scenarios.json
@@ -43,7 +43,8 @@
             "zizmor": {},
             "open-code-review": {},
             "skillspector": {},
-            "herdr": {}
+            "herdr": {},
+            "officecli": {}
         }
     },
     "flux-specific-version": {
@@ -361,6 +362,14 @@
         "features": {
             "herdr": {
                 "version": "v0.7.3"
+            }
+        }
+    },
+    "officecli-specific-version": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "officecli": {
+                "version": "v1.0.139"
             }
         }
     }

--- a/test/_global/scenarios.json
+++ b/test/_global/scenarios.json
@@ -75,7 +75,7 @@
         "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
         "features": {
             "kyverno": {
-                "version": "v1.15.2"
+                "version": "v1.18.2"
             }
         }
     },

--- a/test/officecli/test.sh
+++ b/test/officecli/test.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+source dev-container-features-test-lib
+check "officecli" officecli --version
+reportResults


### PR DESCRIPTION
Adds the `officecli` Dev Container Feature installing [iOfficeAI/OfficeCLI](https://github.com/iOfficeAI/OfficeCLI) from GitHub Releases.

- Multi-arch: linux x64/arm64
- Runtime dep: libicu (installed via check_packages)
- Version option defaults to `latest` via GitHub API
- Tests: basic smoke + version-pinned scenario (v1.0.139)

Verified with `devcontainer features test -f officecli -i ubuntu:latest` ✅