### PR TITLE
feat: add strix dev container feature

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -54,6 +54,7 @@ jobs:
           - skillspector
           - herdr
           - officecli
+          - strix
         baseImage:
           - debian:latest
           - ubuntu:latest

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ This repository contains a _collection_ of Features.
 | SkillSpector | https://github.com/NVIDIA/SkillSpector | Standalone security scanner for local AI-agent skill/config files; useful only if you want an AI-dev-security feature. |
 | herdr | https://github.com/ogulcancelik/herdr | Fast, cross-platform CLI tool distributed as a static binary via GitHub releases. |
 | officecli | https://github.com/iOfficeAI/OfficeCLI | AI-friendly CLI to read, edit, and automate Word, Excel, and PowerPoint files — single static binary, no Office install required. |
+| strix | https://github.com/usestrix/strix | Open-source AI penetration testing tool to find and fix your app's vulnerabilities. |
 
 
 
@@ -772,19 +773,19 @@ Running `herdr --version` inside the built container will print the version of h
 herdr --version
 ```
 
-### `officecli`
+### `strix`
 
-Running `officecli --version` inside the built container will print the version of officecli.
+Running `strix --version` inside the built container will print the version of strix.
 
 ```jsonc
 {
     "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
     "features": {
-        "ghcr.io/jsburckhardt/devcontainer-features/officecli:1": {}
+        "ghcr.io/jsburckhardt/devcontainer-features/strix:1": {}
     }
 }
 ```
 
 ```bash
-officecli --version
+strix --version
 ```

--- a/src/strix/devcontainer-feature.json
+++ b/src/strix/devcontainer-feature.json
@@ -1,0 +1,14 @@
+{
+    "name": "Strix",
+    "id": "strix",
+    "version": "1.0.0",
+    "description": "Open-source AI penetration testing tool to find and fix your app's vulnerabilities. Installs the strix CLI from GitHub releases.",
+    "documentationURL": "https://github.com/usestrix/strix",
+    "options": {
+        "version": {
+            "type": "string",
+            "default": "latest",
+            "description": "Version of strix to install from GitHub releases e.g. 1.1.0"
+        }
+    }
+}

--- a/src/strix/install.sh
+++ b/src/strix/install.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+
+# Variables
+REPO_OWNER="usestrix"
+REPO_NAME="strix"
+STRIX_VERSION="${VERSION:-"latest"}"
+
+set -euo pipefail
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+# Checks if packages are installed and installs them if not
+check_packages() {
+    if ! dpkg -s "$@" >/dev/null 2>&1; then
+        if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+            echo "Running apt-get update..."
+            apt-get update -y
+        fi
+        apt-get -y install --no-install-recommends "$@"
+    fi
+}
+
+# Make sure we have curl, ca-certificates, tar, and jq
+check_packages curl ca-certificates tar jq
+
+echo "Installing Strix version: $STRIX_VERSION"
+
+# Determine the OS and architecture
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+
+case "$OS" in
+    linux)
+        PLATFORM="linux"
+        ;;
+    *)
+        echo "ERROR: Unsupported OS: $OS"
+        echo "Supported OS: Linux"
+        exit 1
+        ;;
+esac
+
+case "$ARCH" in
+    x86_64 | amd64)
+        ARCH_SUFFIX="x86_64"
+        ;;
+    *)
+        echo "ERROR: Unsupported architecture: $ARCH"
+        echo "Strix only publishes prebuilt Linux binaries for x86_64."
+        exit 1
+        ;;
+esac
+
+# Function to resolve the latest version using GitHub API
+resolve_latest_version() {
+    echo "Resolving latest version using GitHub API..." >&2
+    local api_response
+    api_response=$(curl -s --max-time 10 "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases/latest" 2>/dev/null || echo "")
+
+    if [ -n "$api_response" ] && echo "$api_response" | jq -e '.tag_name' >/dev/null 2>&1; then
+        local version_tag
+        version_tag=$(echo "$api_response" | jq -r '.tag_name')
+        # Remove 'v' prefix if present
+        echo "${version_tag#v}"
+        return 0
+    else
+        echo "GitHub API failed, falling back to HTML parsing..." >&2
+        return 1
+    fi
+}
+
+# Function to resolve latest version by parsing HTML (fallback)
+resolve_latest_version_fallback() {
+    echo "Attempting to resolve latest version from releases page HTML..." >&2
+    local releases_page
+    releases_page=$(curl -s --max-time 10 "https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/latest" 2>/dev/null || echo "")
+
+    if [ -n "$releases_page" ]; then
+        local version_tag
+        version_tag=$(echo "$releases_page" | grep -oE 'releases/tag/v?[0-9]+\.[0-9]+\.[0-9]+' | head -1 | sed 's/.*releases\/tag\/v\?\([0-9]\+\.[0-9]\+\.[0-9]\+\).*/\1/')
+
+        if [ -n "$version_tag" ] && [[ "$version_tag" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "$version_tag"
+            return 0
+        fi
+    fi
+
+    echo "Failed to resolve version from HTML, using known fallback version..." >&2
+    echo "1.1.0"
+    return 1
+}
+
+# Resolve version
+if [ "$STRIX_VERSION" = "latest" ] || [ -z "$STRIX_VERSION" ]; then
+    if ! RESOLVED_VERSION=$(resolve_latest_version); then
+        RESOLVED_VERSION=$(resolve_latest_version_fallback) || true
+    fi
+    echo "Resolved latest version to: $RESOLVED_VERSION"
+    STRIX_VERSION="$RESOLVED_VERSION"
+else
+    echo "Using specified version: $STRIX_VERSION"
+    # Remove 'v' prefix if present in user input
+    STRIX_VERSION="${STRIX_VERSION#v}"
+fi
+
+# Construct download URL based on strix's release pattern
+# Asset name format: strix-{version}-{platform}-{arch}.tar.gz
+ASSET_NAME="strix-${STRIX_VERSION}-${PLATFORM}-${ARCH_SUFFIX}.tar.gz"
+DOWNLOAD_URL="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/v${STRIX_VERSION}/${ASSET_NAME}"
+
+echo "Downloading Strix from: ${DOWNLOAD_URL}"
+
+# Create temporary directory
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+cd "$TMP_DIR"
+
+# Download with retries and proper error handling
+for attempt in 1 2 3; do
+    if curl -fL --retry 3 --retry-delay 2 -o "${ASSET_NAME}" "${DOWNLOAD_URL}"; then
+        echo "Download successful on attempt $attempt"
+        break
+    else
+        echo "Download attempt $attempt failed"
+        if [ $attempt -eq 3 ]; then
+            echo "ERROR: Failed to download after 3 attempts"
+            exit 1
+        fi
+        sleep 2
+    fi
+done
+
+# Verify the download
+if [ ! -f "${ASSET_NAME}" ] || [ ! -s "${ASSET_NAME}" ]; then
+    echo "ERROR: Downloaded file is missing or empty"
+    exit 1
+fi
+
+echo "Extracting Strix..."
+tar -xzf "${ASSET_NAME}"
+
+# The archive contains a single binary named strix-{version}-{platform}-{arch}
+BINARY_SRC="strix-${STRIX_VERSION}-${PLATFORM}-${ARCH_SUFFIX}"
+if [ -f "${BINARY_SRC}" ]; then
+    echo "Installing strix..."
+    mv "${BINARY_SRC}" /usr/local/bin/strix
+    chmod +x /usr/local/bin/strix
+elif [ -f "strix" ]; then
+    echo "Installing strix..."
+    mv "strix" /usr/local/bin/strix
+    chmod +x /usr/local/bin/strix
+else
+    echo "ERROR: Could not find strix binary in archive"
+    echo "Archive contents:"
+    ls -la
+    exit 1
+fi
+
+# Clean up
+cd - >/dev/null
+rm -rf /var/lib/apt/lists/*
+
+# Verify installation
+echo "Verifying installation..."
+strix --version
+echo "Strix installation completed successfully!"
+
+echo "Done!"

--- a/test/_global/all-tools.sh
+++ b/test/_global/all-tools.sh
@@ -43,5 +43,6 @@ check "open-code-review" opencodereview --version
 check "skillspector" skillspector --version
 check "herdr" herdr --version
 check "officecli" officecli --version
+check "strix" strix --version
 
 reportResults

--- a/test/_global/scenarios.json
+++ b/test/_global/scenarios.json
@@ -44,7 +44,8 @@
             "open-code-review": {},
             "skillspector": {},
             "herdr": {},
-            "officecli": {}
+            "officecli": {},
+            "strix": {}
         }
     },
     "flux-specific-version": {
@@ -370,6 +371,14 @@
         "features": {
             "officecli": {
                 "version": "v1.0.139"
+            }
+        }
+    },
+    "strix-specific-version": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "strix": {
+                "version": "1.0.4"
             }
         }
     }

--- a/test/_global/strix-specific-version.sh
+++ b/test/_global/strix-specific-version.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+source dev-container-features-test-lib
+check "strix with specific version" /bin/bash -c "strix --version | grep '1.0.4'"
+
+reportResults

--- a/test/strix/test.sh
+++ b/test/strix/test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+source dev-container-features-test-lib
+check "strix" strix --version
+reportResults


### PR DESCRIPTION
Adds the `strix` Dev Container Feature installing [usestrix/strix](https://github.com/usestrix/strix) from GitHub Releases.

- Linux x86_64 only (upstream doesn't ship arm64); clean error on other arches
- Version option defaults to `latest` via GitHub API
- Tests: basic smoke + version-pinned scenario (1.0.4)

Verified with `devcontainer features test -f strix -i ubuntu:latest` ✅