### PR TITLE
feat: add gitai dev container feature

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,6 +56,7 @@ jobs:
           - officecli
           - strix
           - colibri
+          - gitai
         baseImage:
           - debian:latest
           - ubuntu:latest

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This repository contains a _collection_ of Features.
 | zizmor | https://github.com/zizmorcore/zizmor | Static security analysis for GitHub Actions workflows. |
 | open-code-review | https://github.com/alibaba/open-code-review | CLI-oriented code review tool for diffs with deterministic checks plus optional LLM review. |
 | SkillSpector | https://github.com/NVIDIA/SkillSpector | Standalone security scanner for local AI-agent skill/config files; useful only if you want an AI-dev-security feature. |
-| herdr | https://github.com/ogulcancelik/herdr | Fast, cross-platform CLI tool distributed as a static binary via GitHub releases. |
+| herdr | https://github.com/herdrdev/herdr | Fast, cross-platform CLI tool distributed as a static binary via GitHub releases. |
 | officecli | https://github.com/iOfficeAI/OfficeCLI | AI-friendly CLI to read, edit, and automate Word, Excel, and PowerPoint files — single static binary, no Office install required. |
 | strix | https://github.com/usestrix/strix | Open-source AI penetration testing tool to find and fix your app's vulnerabilities. |
 | colibri | https://github.com/JustVugg/colibri | Run GLM-5.2 (744B MoE) on a consumer machine — pure C, zero deps, experts streamed from disk. |

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ This repository contains a _collection_ of Features.
 | officecli | https://github.com/iOfficeAI/OfficeCLI | AI-friendly CLI to read, edit, and automate Word, Excel, and PowerPoint files — single static binary, no Office install required. |
 | strix | https://github.com/usestrix/strix | Open-source AI penetration testing tool to find and fix your app's vulnerabilities. |
 | colibri | https://github.com/JustVugg/colibri | Run GLM-5.2 (744B MoE) on a consumer machine — pure C, zero deps, experts streamed from disk. |
+| gitai | https://github.com/git-ai-project/git-ai | A Git extension for tracking AI-generated code through every commit, merge, rebase, cherry-pick, etc. |
 
 
 
@@ -790,4 +791,21 @@ Running `colibri` inside the built container will print the usage banner of coli
 ```bash
 colibri
 cat /usr/local/share/colibri/VERSION
+```
+
+### `gitai`
+
+Running `git-ai` inside the built container will print the version of the Git AI extension for tracking AI-generated code across commits, merges, rebases, and cherry-picks.
+
+```jsonc
+{
+    "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+    "features": {
+        "ghcr.io/jsburckhardt/devcontainer-features/gitai:1": {}
+    }
+}
+```
+
+```bash
+git-ai --version
 ```

--- a/src/gitai/devcontainer-feature.json
+++ b/src/gitai/devcontainer-feature.json
@@ -1,0 +1,13 @@
+{
+    "name": "Git AI",
+    "id": "gitai",
+    "version": "1.0.0",
+    "description": "A Git extension for tracking AI-generated code through every commit, merge, rebase, cherry-pick, etc.",
+    "options": {
+        "version": {
+            "type": "string",
+            "default": "latest",
+            "description": "Version of git-ai to install from GitHub releases e.g. v1.6.21"
+        }
+    }
+}

--- a/src/gitai/install.sh
+++ b/src/gitai/install.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Variables
+REPO_OWNER="git-ai-project"
+REPO_NAME="git-ai"
+BINARY_NAME="git-ai"
+
+# Root check
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+check_packages() {
+    if ! dpkg -s "$@" >/dev/null 2>&1; then
+        if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+            echo "Running apt-get update..."
+            apt-get update -y
+        fi
+        apt-get -y install --no-install-recommends "$@"
+    fi
+}
+
+# Ensure required packages are installed
+check_packages curl ca-certificates jq
+
+# Function to get the latest version from GitHub API
+get_latest_version() {
+    LATEST_URL="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases/latest"
+    curl -s "$LATEST_URL" | jq -r ".tag_name"
+}
+
+# Resolve version
+if [ -z "${VERSION:-}" ] || [ "${VERSION}" = "latest" ]; then
+    VERSION="$(get_latest_version)"
+    if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
+        echo "Failed to resolve latest version from GitHub API." >&2
+        exit 1
+    fi
+    echo "No version provided or 'latest' specified, installing the latest version: $VERSION"
+else
+    echo "Installing version from environment variable: $VERSION"
+fi
+
+# Normalize version tag: upstream release tags are prefixed with "v" (e.g. v1.6.21).
+# If the user supplied a bare semver like "1.6.21", prepend "v".
+case "$VERSION" in
+    v*) ;;
+    *) VERSION="v${VERSION}" ;;
+esac
+
+# Determine OS
+OS_RAW="$(uname -s)"
+case "$OS_RAW" in
+    Linux)  OS="linux" ;;
+    Darwin) OS="macos" ;;
+    *) echo "Unsupported OS: $OS_RAW" >&2; exit 1 ;;
+esac
+
+# Determine architecture. Upstream publishes raw binaries named:
+#   git-ai-linux-x64, git-ai-linux-arm64, git-ai-macos-x64, git-ai-macos-arm64
+ARCH_RAW="$(uname -m)"
+case "$ARCH_RAW" in
+    x86_64|amd64)  ARCH="x64" ;;
+    aarch64|arm64) ARCH="arm64" ;;
+    *) echo "Unsupported architecture: $ARCH_RAW" >&2; exit 1 ;;
+esac
+
+ASSET_NAME="${BINARY_NAME}-${OS}-${ARCH}"
+DOWNLOAD_URL="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/${VERSION}/${ASSET_NAME}"
+
+# Download the raw binary directly (no tarball is published by upstream)
+TMP_DIR="$(mktemp -d)"
+cd "$TMP_DIR"
+
+echo "Downloading $BINARY_NAME from $DOWNLOAD_URL"
+curl -fsSL -o "$BINARY_NAME" "$DOWNLOAD_URL"
+
+chmod +x "$BINARY_NAME"
+mv "$BINARY_NAME" /usr/local/bin/
+
+# Cleanup
+cd /
+rm -rf "$TMP_DIR"
+rm -rf /var/lib/apt/lists/*
+
+# Verify installation
+echo "Verifying installation"
+"$BINARY_NAME" --version
+
+echo "Done!"

--- a/src/herdr/README.md
+++ b/src/herdr/README.md
@@ -1,7 +1,7 @@
 
 # herdr (herdr)
 
-herdr is a fast, cross-platform CLI tool from ogulcancelik/herdr distributed as a static binary via GitHub releases.
+herdr is a fast, cross-platform CLI tool from herdrdev/herdr distributed as a static binary via GitHub releases.
 
 ## Example Usage
 

--- a/src/herdr/devcontainer-feature.json
+++ b/src/herdr/devcontainer-feature.json
@@ -2,7 +2,7 @@
     "name": "herdr",
     "id": "herdr",
     "version": "1.0.0",
-    "description": "herdr is a fast, cross-platform CLI tool from ogulcancelik/herdr distributed as a static binary via GitHub releases.",
+    "description": "herdr is a fast, cross-platform CLI tool from herdrdev/herdr distributed as a static binary via GitHub releases.",
     "options": {
         "version": {
             "type": "string",

--- a/src/herdr/install.sh
+++ b/src/herdr/install.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Variables
-REPO_OWNER="ogulcancelik"
+REPO_OWNER="herdrdev"
 REPO_NAME="herdr"
 BINARY_NAME="herdr"
 
@@ -32,7 +32,7 @@ check_packages curl ca-certificates jq tar
 # Function to get the latest version from GitHub API
 get_latest_version() {
     LATEST_URL="https://api.github.com/repos/$REPO_OWNER/$REPO_NAME/releases/latest"
-    curl -s "$LATEST_URL" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'
+    curl -sL "$LATEST_URL" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'
 }
 
 # Resolve version

--- a/test/_global/all-tools.sh
+++ b/test/_global/all-tools.sh
@@ -45,5 +45,6 @@ check "herdr" herdr --version
 check "officecli" officecli --version
 check "strix" strix --version
 check "colibri" bash -c "command -v colibri"
+check "gitai" git-ai --version
 
 reportResults

--- a/test/_global/gitai-specific-version.sh
+++ b/test/_global/gitai-specific-version.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+source dev-container-features-test-lib
+check "gitai with specific version" /bin/bash -c "git-ai --version | grep '1.6.21'"
+reportResults

--- a/test/_global/scenarios.json
+++ b/test/_global/scenarios.json
@@ -46,7 +46,8 @@
             "herdr": {},
             "officecli": {},
             "strix": {},
-            "colibri": {}
+            "colibri": {},
+            "gitai": {}
         }
     },
     "flux-specific-version": {
@@ -388,6 +389,14 @@
         "features": {
             "colibri": {
                 "version": "v1.0.0"
+            }
+        }
+    },
+    "gitai-specific-version": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "gitai": {
+                "version": "v1.6.21"
             }
         }
     }

--- a/test/gitai/test.sh
+++ b/test/gitai/test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+source dev-container-features-test-lib
+check "gitai" git-ai --version
+reportResults


### PR DESCRIPTION
Adds a new dev container feature that installs [`git-ai`](https://github.com/git-ai-project/git-ai) from [usegitai.com](https://usegitai.com/) — a Git extension for tracking AI-generated code through commits, merges, rebases, and cherry-picks.

## What it does
- Downloads the raw `git-ai-linux-{x64,arm64}` binary from GitHub releases (upstream does not ship tarballs)
- Installs to `/usr/local/bin/git-ai`
- Version defaults to `latest` (resolved via GitHub API); accepts pinned tags like `v1.6.21` or bare `1.6.21` (normalized)

## Verification
- `devcontainer features test -f gitai -i ubuntu:latest .` ✅
- `devcontainer features test --global-scenarios-only --filter gitai-specific-version .` ✅ (pins v1.6.21)

## Files
- **Created:** `src/gitai/{devcontainer-feature.json,install.sh}`, `test/gitai/test.sh`, `test/_global/gitai-specific-version.sh`
- **Updated:** `test/_global/{all-tools.sh,scenarios.json}`, `.github/workflows/test.yaml`, `README.md`