### PR TITLE
fix(herdr): update repo owner to herdrdev after transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This repository contains a _collection_ of Features.
 | zizmor | https://github.com/zizmorcore/zizmor | Static security analysis for GitHub Actions workflows. |
 | open-code-review | https://github.com/alibaba/open-code-review | CLI-oriented code review tool for diffs with deterministic checks plus optional LLM review. |
 | SkillSpector | https://github.com/NVIDIA/SkillSpector | Standalone security scanner for local AI-agent skill/config files; useful only if you want an AI-dev-security feature. |
-| herdr | https://github.com/ogulcancelik/herdr | Fast, cross-platform CLI tool distributed as a static binary via GitHub releases. |
+| herdr | https://github.com/herdrdev/herdr | Fast, cross-platform CLI tool distributed as a static binary via GitHub releases. |
 | officecli | https://github.com/iOfficeAI/OfficeCLI | AI-friendly CLI to read, edit, and automate Word, Excel, and PowerPoint files — single static binary, no Office install required. |
 | strix | https://github.com/usestrix/strix | Open-source AI penetration testing tool to find and fix your app's vulnerabilities. |
 | colibri | https://github.com/JustVugg/colibri | Run GLM-5.2 (744B MoE) on a consumer machine — pure C, zero deps, experts streamed from disk. |

--- a/src/herdr/README.md
+++ b/src/herdr/README.md
@@ -1,7 +1,7 @@
 
 # herdr (herdr)
 
-herdr is a fast, cross-platform CLI tool from ogulcancelik/herdr distributed as a static binary via GitHub releases.
+herdr is a fast, cross-platform CLI tool from herdrdev/herdr distributed as a static binary via GitHub releases.
 
 ## Example Usage
 

--- a/src/herdr/devcontainer-feature.json
+++ b/src/herdr/devcontainer-feature.json
@@ -2,7 +2,7 @@
     "name": "herdr",
     "id": "herdr",
     "version": "1.0.0",
-    "description": "herdr is a fast, cross-platform CLI tool from ogulcancelik/herdr distributed as a static binary via GitHub releases.",
+    "description": "herdr is a fast, cross-platform CLI tool from herdrdev/herdr distributed as a static binary via GitHub releases.",
     "options": {
         "version": {
             "type": "string",

--- a/src/herdr/install.sh
+++ b/src/herdr/install.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Variables
-REPO_OWNER="ogulcancelik"
+REPO_OWNER="herdrdev"
 REPO_NAME="herdr"
 BINARY_NAME="herdr"
 
@@ -32,7 +32,7 @@ check_packages curl ca-certificates jq tar
 # Function to get the latest version from GitHub API
 get_latest_version() {
     LATEST_URL="https://api.github.com/repos/$REPO_OWNER/$REPO_NAME/releases/latest"
-    curl -s "$LATEST_URL" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'
+    curl -sL "$LATEST_URL" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'
 }
 
 # Resolve version


### PR DESCRIPTION
## Problem
The upstream `herdr` repo was transferred from `ogulcancelik/herdr` → [`herdrdev/herdr`](https://github.com/herdrdev/herdr). GitHub's API returns `301 Moved Permanently` for the old path, and `install.sh` used `curl -s` (no `-L`), so `get_latest_version` returned empty and the feature failed to install:

```
Failed to resolve latest version from GitHub API.
ERROR: Feature "herdr" (Unknown) failed to install!
```

CI didn't catch this because `test.yaml` only runs on changes to `src/**`/`test/**`, so main-branch builds haven't re-exercised herdr's install path since the transfer.

## Fix
- Point `REPO_OWNER` at `herdrdev`
- Add `-L` to the `get_latest_version` curl so future redirects don't silently break
- Update descriptions and README links

## Verification
```
devcontainer features test -f herdr -i ubuntu:latest .
# → 'herdr 0.8.0' ✅
```